### PR TITLE
Update README and community docs for public launch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,23 +1,33 @@
 # Contributing
 
-Thanks for contributing to Divelog.
+Thanks for your interest in Profundum.
 
-## Getting started
-- Read `docs/DEVELOPMENT_GUIDELINES.md`.
-- Run formatting and tests before submitting a PR.
+## Getting Started
 
-## Pull requests
-- Keep PRs focused and small.
-- Include a clear summary and rationale.
-- Add or update tests when changing core logic.
+1. Clone the repo (with submodules): `git clone --recurse-submodules`
+2. Install the Rust toolchain: [rustup.rs](https://rustup.rs)
+3. Build: `make all`
+4. Run tests: `make test`
 
-## Code style
-- Rust: `cargo fmt` + `cargo clippy` clean.
-- Kotlin/Swift: follow platform idioms and keep APIs stable.
+## Pull Requests
 
-## Reporting issues
-- Provide reproduction steps and expected behavior.
-- Include logs or screenshots when relevant.
+- Create a feature branch from `main`
+- Keep PRs focused and small
+- Include a clear summary and rationale
+- Add or update tests when changing core logic
+- CI must pass (`swift-test`, `version-check`) before merge
+
+## Code Style
+
+- **Rust**: `cargo fmt` + `cargo clippy` clean (`make lint`)
+- **Swift**: follow existing patterns — GRDB records use `Codable + FetchableRecord + PersistableRecord` with explicit `CodingKeys`
+
+## Reporting Issues
+
+- Use GitHub Issues
+- Provide reproduction steps and expected behavior
+- Include OS version, device info, and logs when relevant
 
 ## License
-By contributing, you agree that your contributions will be licensed under the project license.
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,20 +1,101 @@
-# Divelog (macOS + iOS, shared backend)
+# Profundum
 
-This repo is the starting point for native apps backed by a single cross-platform core. The frontends are separate native apps, while the backend core handles BLE ingestion, parsing, storage, and analytics.
+An open-source dive log for iOS and macOS. Local-first, privacy-first.
 
-## Why start here
-- Shared core reduces duplication across platforms for BLE parsing, derived metrics, and persistence.
-- Native UIs keep platform fidelity and enable richer OS integrations.
-- Rust + UniFFI is a practical cross-platform core that can be linked into Swift, Kotlin, and other native targets.
+Profundum records and analyzes scuba dives — open-circuit and closed-circuit rebreather (CCR). It imports dives from Shearwater Cloud databases and BLE dive computers via [libdivecomputer](https://www.libdivecomputer.org/), stores everything locally with GRDB, and uses a Rust compute core for formula parsing and dive metrics.
 
-## Repo layout
-- `core/`: cross-platform backend (Rust)
-- `apps/macos/`: macOS app (SwiftUI)
-- `apps/ios/`: iOS app (SwiftUI)
-- `apps/compose/`: shared Compose Multiplatform UI module
-- `apps/android/`: Android app (Compose Multiplatform)
-- `apps/desktop/`: Windows + Linux desktop app (Compose Multiplatform)
-- `docs/`: architecture + roadmap
+## Features
 
-## Next steps
-See `docs/ARCHITECTURE.md` and `docs/ROADMAP.md` for the initial build plan.
+- **Dive logging** with depth profiles, gas mixes, deco status, CNS/OTU tracking
+- **Multi-computer merge** — dives from multiple computers within a 120-second window are grouped automatically
+- **Shearwater Cloud import** — import directly from Shearwater's `.db` export files
+- **BLE dive computer import** — connect to dive computers over Bluetooth Low Energy
+- **Interactive charts** — depth profile and PPO2 traces with scrub-to-inspect (Swift Charts)
+- **Custom formulas** — user-defined calculated fields using dive variables (e.g., `deco_time_min / bottom_time_min`)
+- **VoiceOver accessible** — semantic grouping, chart summaries, filter state announcements
+- **Export** — JSON export/import for backup and data portability
+
+## Architecture
+
+```
+Swift Layer (native)
+├── Profundum           SwiftUI multiplatform app (iOS + macOS)
+├── DivelogCore         Swift package — GRDB storage, models, services
+├── CoreBluetooth       BLE dive computer communication
+└── libdivecomputer     C library for dive computer protocol parsing
+
+Rust Compute Core (~500 lines, stateless)
+├── Formula parser      nom-based expression parsing and evaluation
+└── Metrics engine      DiveStats, SegmentStats from pure inputs
+```
+
+Swift owns all storage and UI. Rust handles stateless computation. They communicate via UniFFI-generated bindings packaged as an XCFramework.
+
+## Requirements
+
+- Xcode 15+ (Swift 5.9)
+- Rust toolchain (for building the compute core)
+- iOS 16+ / macOS 13+
+
+## Building
+
+```bash
+# Build everything (Rust XCFramework + Swift package)
+make all
+
+# Run all tests (Rust + Swift)
+make test
+
+# See all available targets
+make help
+```
+
+For BLE dive computer support, also build the libdivecomputer XCFramework:
+
+```bash
+make libdivecomputer-xcframework
+```
+
+See [docs/uniffi-build.md](docs/uniffi-build.md) for details on the Rust-to-Swift build pipeline.
+
+## Repository Layout
+
+```
+Profundum/              Multiplatform SwiftUI app (iOS + macOS)
+apple/DivelogCore/      Swift package — models, database, services
+core/                   Rust compute core (formula parser, metrics)
+libdivecomputer/        Submodule + XCFramework build for dive computer protocols
+scripts/                Version sync, build verification
+docs/                   Architecture and design documents
+```
+
+## Development
+
+```bash
+# Rust lint + format check
+make lint
+
+# Swift tests only
+make swift-test
+
+# Rust tests only
+make rust-test
+
+# Check monorepo version consistency
+make version-check
+```
+
+Branch protection is enabled on `main`. All changes go through pull requests with required CI checks (`swift-test`, `version-check`).
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines. In short:
+
+1. Create a feature branch
+2. Make your changes with tests
+3. Open a PR — CI runs automatically
+4. Address review feedback and merge
+
+## License
+
+[MIT](LICENSE)

--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -1,11 +1,25 @@
-# Third‑Party Licenses
+# Third-Party Licenses
 
-List third‑party dependencies and their licenses here.
+## Rust (core/)
 
-## Core
-- `rusqlite` — MIT
-- `uniffi` — MPL 2.0
+| Dependency | License |
+|-----------|---------|
+| [UniFFI](https://github.com/mozilla/uniffi-rs) | MPL 2.0 |
+| [nom](https://github.com/rust-bakery/nom) | MIT |
+| [thiserror](https://github.com/dtolnay/thiserror) | MIT / Apache 2.0 |
 
-## UI (planned)
-- Compose Multiplatform — Apache 2.0
-- SwiftUI — Apple SDK license
+## Swift (apple/DivelogCore/)
+
+| Dependency | License |
+|-----------|---------|
+| [GRDB.swift](https://github.com/groue/GRDB.swift) | MIT |
+
+## C (libdivecomputer/)
+
+| Dependency | License |
+|-----------|---------|
+| [libdivecomputer](https://www.libdivecomputer.org/) | LGPL 2.1 |
+
+## System Frameworks
+
+- SwiftUI, CoreBluetooth, Charts — Apple SDK license


### PR DESCRIPTION
## Summary

- Rewrite README to reflect actual project state: architecture, features, build instructions, repo layout
- Update CONTRIBUTING.md with clone/build/PR workflow and accurate code style guidance
- Correct THIRD_PARTY.md to list real dependencies (GRDB, nom, thiserror, UniFFI, libdivecomputer) instead of stale placeholders (rusqlite, Compose Multiplatform)

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm all links resolve (LICENSE, CONTRIBUTING, docs/uniffi-build.md)
- [ ] Check `make help` output matches README build instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)