### PR TITLE
Fix gas switch overcounting and duplicate gas mixes

### DIFF
--- a/Profundum/Profundum/Views/DiveDetailView.swift
+++ b/Profundum/Profundum/Views/DiveDetailView.swift
@@ -588,7 +588,8 @@ struct DiveDetailView: View {
                     tempC: sample.tempC,
                     setpointPpo2: sample.setpointPpo2,
                     ceilingM: sample.ceilingM,
-                    gf99: sample.gf99
+                    gf99: sample.gf99,
+                    gasmixIndex: sample.gasmixIndex.map { Int32($0) }
                 )
             }
 

--- a/apple/DivelogCore/Sources/Services/FormulaService.swift
+++ b/apple/DivelogCore/Sources/Services/FormulaService.swift
@@ -144,7 +144,8 @@ public final class FormulaService: Sendable {
                 tempC: sample.tempC,
                 setpointPpo2: sample.setpointPpo2,
                 ceilingM: sample.ceilingM,
-                gf99: sample.gf99
+                gf99: sample.gf99,
+                gasmixIndex: sample.gasmixIndex.map { Int32($0) }
             )
         }
 
@@ -159,7 +160,8 @@ public final class FormulaService: Sendable {
                 tempC: sample.tempC,
                 setpointPpo2: sample.setpointPpo2,
                 ceilingM: sample.ceilingM,
-                gf99: sample.gf99
+                gf99: sample.gf99,
+                gasmixIndex: sample.gasmixIndex.map { Int32($0) }
             )
         }
 

--- a/apple/DivelogCore/Tests/DivelogCoreTests.swift
+++ b/apple/DivelogCore/Tests/DivelogCoreTests.swift
@@ -211,11 +211,11 @@ final class DivelogCoreTests: XCTestCase {
         )
 
         let samples = [
-            SampleInput(tSec: 0, depthM: 0.0, tempC: 22.0, setpointPpo2: nil, ceilingM: nil, gf99: nil),
-            SampleInput(tSec: 60, depthM: 10.0, tempC: 20.0, setpointPpo2: nil, ceilingM: nil, gf99: nil),
-            SampleInput(tSec: 120, depthM: 30.0, tempC: 16.0, setpointPpo2: nil, ceilingM: nil, gf99: nil),
-            SampleInput(tSec: 300, depthM: 30.0, tempC: 16.0, setpointPpo2: nil, ceilingM: nil, gf99: nil),
-            SampleInput(tSec: 600, depthM: 0.0, tempC: 20.0, setpointPpo2: nil, ceilingM: nil, gf99: nil),
+            SampleInput(tSec: 0, depthM: 0.0, tempC: 22.0, setpointPpo2: nil, ceilingM: nil, gf99: nil, gasmixIndex: nil),
+            SampleInput(tSec: 60, depthM: 10.0, tempC: 20.0, setpointPpo2: nil, ceilingM: nil, gf99: nil, gasmixIndex: nil),
+            SampleInput(tSec: 120, depthM: 30.0, tempC: 16.0, setpointPpo2: nil, ceilingM: nil, gf99: nil, gasmixIndex: nil),
+            SampleInput(tSec: 300, depthM: 30.0, tempC: 16.0, setpointPpo2: nil, ceilingM: nil, gf99: nil, gasmixIndex: nil),
+            SampleInput(tSec: 600, depthM: 0.0, tempC: 20.0, setpointPpo2: nil, ceilingM: nil, gf99: nil, gasmixIndex: nil),
         ]
 
         let stats = DivelogCompute.computeDiveStats(dive: diveInput, samples: samples)
@@ -228,10 +228,10 @@ final class DivelogCoreTests: XCTestCase {
 
     func testComputeSegmentStats() {
         let samples = [
-            SampleInput(tSec: 100, depthM: 10.0, tempC: 20.0, setpointPpo2: nil, ceilingM: nil, gf99: nil),
-            SampleInput(tSec: 200, depthM: 25.0, tempC: 18.0, setpointPpo2: nil, ceilingM: nil, gf99: nil),
-            SampleInput(tSec: 300, depthM: 20.0, tempC: 19.0, setpointPpo2: nil, ceilingM: nil, gf99: nil),
-            SampleInput(tSec: 400, depthM: 5.0, tempC: 21.0, setpointPpo2: nil, ceilingM: nil, gf99: nil),
+            SampleInput(tSec: 100, depthM: 10.0, tempC: 20.0, setpointPpo2: nil, ceilingM: nil, gf99: nil, gasmixIndex: nil),
+            SampleInput(tSec: 200, depthM: 25.0, tempC: 18.0, setpointPpo2: nil, ceilingM: nil, gf99: nil, gasmixIndex: nil),
+            SampleInput(tSec: 300, depthM: 20.0, tempC: 19.0, setpointPpo2: nil, ceilingM: nil, gf99: nil, gasmixIndex: nil),
+            SampleInput(tSec: 400, depthM: 5.0, tempC: 21.0, setpointPpo2: nil, ceilingM: nil, gf99: nil, gasmixIndex: nil),
         ]
 
         let stats = DivelogCompute.computeSegmentStats(startTSec: 100, endTSec: 300, samples: samples)

--- a/apple/DivelogCore/Tests/ExtendedTests.swift
+++ b/apple/DivelogCore/Tests/ExtendedTests.swift
@@ -580,8 +580,8 @@ final class FormulaServiceTests: XCTestCase {
         let stats = DivelogCompute.computeDiveStats(
             dive: DiveInput(startTimeUnix: 1700000000, endTimeUnix: 1700003600, bottomTimeSec: 3000),
             samples: [
-                SampleInput(tSec: 0, depthM: 0.0, tempC: 22.0, setpointPpo2: nil, ceilingM: nil, gf99: nil),
-                SampleInput(tSec: 300, depthM: 30.0, tempC: 16.0, setpointPpo2: nil, ceilingM: nil, gf99: nil),
+                SampleInput(tSec: 0, depthM: 0.0, tempC: 22.0, setpointPpo2: nil, ceilingM: nil, gf99: nil, gasmixIndex: nil),
+                SampleInput(tSec: 300, depthM: 30.0, tempC: 16.0, setpointPpo2: nil, ceilingM: nil, gf99: nil, gasmixIndex: nil),
             ]
         )
 
@@ -610,9 +610,9 @@ final class FormulaServiceTests: XCTestCase {
             startTSec: 60,
             endTSec: 300,
             samples: [
-                SampleInput(tSec: 60, depthM: 10.0, tempC: 20.0, setpointPpo2: nil, ceilingM: nil, gf99: nil),
-                SampleInput(tSec: 180, depthM: 25.0, tempC: 18.0, setpointPpo2: nil, ceilingM: nil, gf99: nil),
-                SampleInput(tSec: 300, depthM: 15.0, tempC: 19.0, setpointPpo2: nil, ceilingM: nil, gf99: nil),
+                SampleInput(tSec: 60, depthM: 10.0, tempC: 20.0, setpointPpo2: nil, ceilingM: nil, gf99: nil, gasmixIndex: nil),
+                SampleInput(tSec: 180, depthM: 25.0, tempC: 18.0, setpointPpo2: nil, ceilingM: nil, gf99: nil, gasmixIndex: nil),
+                SampleInput(tSec: 300, depthM: 15.0, tempC: 19.0, setpointPpo2: nil, ceilingM: nil, gf99: nil, gasmixIndex: nil),
             ]
         )
 
@@ -636,8 +636,8 @@ final class FormulaServiceTests: XCTestCase {
         let stats = DivelogCompute.computeDiveStats(
             dive: DiveInput(startTimeUnix: 1700000000, endTimeUnix: 1700003600, bottomTimeSec: 3000),
             samples: [
-                SampleInput(tSec: 0, depthM: 0.0, tempC: 22.0, setpointPpo2: nil, ceilingM: nil, gf99: nil),
-                SampleInput(tSec: 300, depthM: 30.0, tempC: 16.0, setpointPpo2: nil, ceilingM: nil, gf99: nil),
+                SampleInput(tSec: 0, depthM: 0.0, tempC: 22.0, setpointPpo2: nil, ceilingM: nil, gf99: nil, gasmixIndex: nil),
+                SampleInput(tSec: 300, depthM: 30.0, tempC: 16.0, setpointPpo2: nil, ceilingM: nil, gf99: nil, gasmixIndex: nil),
             ]
         )
 

--- a/core/src/divelog_compute.udl
+++ b/core/src/divelog_compute.udl
@@ -63,6 +63,7 @@ dictionary SampleInput {
     f32? setpoint_ppo2;
     f32? ceiling_m;
     f32? gf99;
+    i32? gasmix_index;
 };
 
 // ============================================================================

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -124,6 +124,7 @@ mod tests {
                 setpoint_ppo2: None,
                 ceiling_m: None,
                 gf99: None,
+                gasmix_index: None,
             },
             SampleInput {
                 t_sec: 300,
@@ -132,6 +133,7 @@ mod tests {
                 setpoint_ppo2: None,
                 ceiling_m: Some(3.0),
                 gf99: Some(60.0),
+                gasmix_index: None,
             },
             SampleInput {
                 t_sec: 600,
@@ -140,6 +142,7 @@ mod tests {
                 setpoint_ppo2: None,
                 ceiling_m: None,
                 gf99: None,
+                gasmix_index: None,
             },
         ];
 
@@ -158,6 +161,7 @@ mod tests {
                 setpoint_ppo2: None,
                 ceiling_m: None,
                 gf99: None,
+                gasmix_index: None,
             },
             SampleInput {
                 t_sec: 200,
@@ -166,6 +170,7 @@ mod tests {
                 setpoint_ppo2: None,
                 ceiling_m: None,
                 gf99: None,
+                gasmix_index: None,
             },
             SampleInput {
                 t_sec: 300,
@@ -174,6 +179,7 @@ mod tests {
                 setpoint_ppo2: None,
                 ceiling_m: None,
                 gf99: None,
+                gasmix_index: None,
             },
         ];
 


### PR DESCRIPTION
## Summary
- **Gas switch detection (#25):** Replaced setpoint_ppo2-based detection with gasmix_index-based detection in the Rust metrics engine. CCR dives no longer show ~150 false gas switches from setpoint fluctuations. Added `gasmix_index` field through the full stack: UDL → Rust → UniFFI → Swift → SwiftUI.
- **Duplicate gas mixes (#26):** Added write-time dedup in both BLE import (`DiveComputerImportService`) and Shearwater Cloud import (new-dive and partial-merge paths). Added read-time dedup safety net in `DiveService.getGasMixes()` for pre-existing data.

## Test plan
- [x] Rust: `cargo fmt --check && cargo clippy -- -D warnings && cargo test` — 50 tests pass (2 new: `test_gas_switch_count_by_gasmix_index`, `test_gas_switch_count_setpoint_noise_ignored`)
- [x] Swift: `swift test` — 183 tests pass (2 new: `testSaveImportedDiveDeduplicatesGasMixes`, `testGetGasMixesDeduplicatesAtReadTime`)
- [x] Xcode: `xcodebuild build` succeeds for iOS Simulator
- [x] Manual: verify CCR dive detail shows gas_switch_count = 0 for single-diluent dives
- [x] Manual: verify DiveDetailView no longer shows duplicate gas mix entries

Closes #25, closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)