### PR TITLE
Fix BLE import cross-source duplicate detection (#49)

### DIFF
--- a/apple/DivelogCore/Sources/Services/DiveComputerImportService.swift
+++ b/apple/DivelogCore/Sources/Services/DiveComputerImportService.swift
@@ -19,14 +19,24 @@ public final class DiveComputerImportService: Sendable {
         self.database = database
     }
 
-    /// Checks whether a dive with the given fingerprint already exists.
+    /// Finds an existing dive by fingerprint, checking both the legacy `dives.fingerprint`
+    /// column and the `dive_source_fingerprints` table.
     /// - Parameter fingerprint: The fingerprint blob from the dive computer.
-    /// - Returns: `true` if a dive with this fingerprint is already stored.
-    public func isDuplicate(fingerprint: Data) throws -> Bool {
+    /// - Returns: The existing dive's ID if found, or `nil`.
+    public func findExistingDiveByFingerprint(fingerprint: Data) throws -> String? {
         try database.dbQueue.read { db in
-            try Dive
-                .filter(Column("fingerprint") == fingerprint)
-                .fetchCount(db) > 0
+            try Self.findExistingDiveByFingerprint(fingerprint: fingerprint, db: db)
+        }
+    }
+
+    /// Finds an existing dive by start time from a different device (cross-source dedup).
+    /// - Parameters:
+    ///   - startTimeUnix: The start time to search for.
+    ///   - deviceId: The device ID of the incoming dive (excluded from results).
+    /// - Returns: The existing dive's ID if found within ±300s from a different device, or `nil`.
+    public func findExistingDiveByTime(startTimeUnix: Int64, deviceId: String) throws -> String? {
+        try database.dbQueue.read { db in
+            try Self.findExistingDiveByTime(startTimeUnix: startTimeUnix, deviceId: deviceId, db: db)
         }
     }
 
@@ -49,17 +59,34 @@ public final class DiveComputerImportService: Sendable {
 
     /// Saves an imported dive and its samples transactionally.
     ///
-    /// If a dive with the same fingerprint already exists, the save is skipped
-    /// (idempotent). Returns `true` if the dive was saved, `false` if it was a duplicate.
+    /// Dedup strategy (in order):
+    /// 1. **Fingerprint dedup** — checks both legacy `dives.fingerprint` and
+    ///    `dive_source_fingerprints`. If matched, links the BLE fingerprint to
+    ///    the existing dive and returns `false`.
+    /// 2. **Time-based cross-source dedup** — if a dive with the same
+    ///    `start_time_unix` (±60s) exists from a different device, links the
+    ///    BLE fingerprint to the existing dive and returns `false`.
+    /// 3. **New dive** — inserts dive, tags, samples, gas mixes, and a
+    ///    `DiveSourceFingerprint` record.
+    ///
     /// - Parameters:
     ///   - parsed: The parsed dive data from the dive computer.
     ///   - deviceId: The device ID to associate with the dive.
     /// - Returns: `true` if the dive was newly saved, `false` if skipped as duplicate.
     @discardableResult
     public func saveImportedDive(_ parsed: ParsedDive, deviceId: String) throws -> Bool {
-        // Check fingerprint-based dedup before the write transaction
+        // Pre-check: fingerprint-based dedup (legacy + source_fingerprints)
         if let fp = parsed.fingerprint {
-            if try isDuplicate(fingerprint: fp) {
+            if let existingDiveId = try findExistingDiveByFingerprint(fingerprint: fp) {
+                try linkFingerprint(fp, deviceId: deviceId, toDiveId: existingDiveId)
+                return false
+            }
+
+            // Pre-check: time-based cross-source dedup
+            if let existingDiveId = try findExistingDiveByTime(
+                startTimeUnix: parsed.startTimeUnix, deviceId: deviceId
+            ) {
+                try linkFingerprint(fp, deviceId: deviceId, toDiveId: existingDiveId)
                 return false
             }
         }
@@ -81,12 +108,24 @@ public final class DiveComputerImportService: Sendable {
         }
 
         try database.dbQueue.write { db in
-            // Double-check inside the transaction to avoid TOCTOU races
+            // TOCTOU double-check inside the write transaction
             if let fp = dive.fingerprint {
-                let exists = try Dive
-                    .filter(Column("fingerprint") == fp)
-                    .fetchCount(db) > 0
-                if exists { return }
+                if let existingDiveId = try Self.findExistingDiveByFingerprint(
+                    fingerprint: fp, db: db
+                ) {
+                    try Self.insertSourceFingerprint(
+                        fp, deviceId: deviceId, diveId: existingDiveId, db: db
+                    )
+                    return
+                }
+                if let existingDiveId = try Self.findExistingDiveByTime(
+                    startTimeUnix: dive.startTimeUnix, deviceId: deviceId, db: db
+                ) {
+                    try Self.insertSourceFingerprint(
+                        fp, deviceId: deviceId, diveId: existingDiveId, db: db
+                    )
+                    return
+                }
             }
 
             try dive.insert(db)
@@ -104,6 +143,13 @@ public final class DiveComputerImportService: Sendable {
             for mix in uniqueMixes {
                 try mix.insert(db)
             }
+
+            // Record BLE fingerprint in dive_source_fingerprints for future dedup
+            if let fp = dive.fingerprint {
+                try Self.insertSourceFingerprint(
+                    fp, deviceId: deviceId, diveId: dive.id, db: db
+                )
+            }
         }
 
         return true
@@ -120,5 +166,70 @@ public final class DiveComputerImportService: Sendable {
             saved += 1
         }
         return saved
+    }
+
+    // MARK: - Private Helpers
+
+    /// Checks both the legacy `dives.fingerprint` column and the `dive_source_fingerprints`
+    /// table for a matching fingerprint. Returns the existing dive ID if found.
+    private static func findExistingDiveByFingerprint(
+        fingerprint: Data, db: Database
+    ) throws -> String? {
+        // Check legacy dives.fingerprint column
+        if let dive = try Dive
+            .filter(Column("fingerprint") == fingerprint)
+            .fetchOne(db) {
+            return dive.id
+        }
+        // Check dive_source_fingerprints table
+        if let sourceFp = try DiveSourceFingerprint
+            .filter(Column("fingerprint") == fingerprint)
+            .fetchOne(db) {
+            return sourceFp.diveId
+        }
+        return nil
+    }
+
+    /// Finds an existing dive by start time from a different device.
+    /// Uses ±300s tolerance to handle clock drift between import paths.
+    /// 5 minutes is well under the shortest realistic surface interval.
+    private static func findExistingDiveByTime(
+        startTimeUnix: Int64, deviceId: String, db: Database
+    ) throws -> String? {
+        let row = try Row.fetchOne(db, sql: """
+            SELECT id FROM dives
+            WHERE ABS(start_time_unix - ?) <= 300
+              AND device_id != ?
+            LIMIT 1
+            """, arguments: [startTimeUnix, deviceId])
+        return row?["id"] as String?
+    }
+
+    /// Links an existing dive to a new BLE fingerprint (skips if already linked).
+    private func linkFingerprint(
+        _ fingerprint: Data, deviceId: String, toDiveId diveId: String
+    ) throws {
+        try database.dbQueue.write { db in
+            try Self.insertSourceFingerprint(
+                fingerprint, deviceId: deviceId, diveId: diveId, db: db
+            )
+        }
+    }
+
+    /// Inserts a `DiveSourceFingerprint` record if one with the same fingerprint
+    /// doesn't already exist.
+    private static func insertSourceFingerprint(
+        _ fingerprint: Data, deviceId: String, diveId: String, db: Database
+    ) throws {
+        let exists = try DiveSourceFingerprint
+            .filter(Column("fingerprint") == fingerprint)
+            .fetchCount(db) > 0
+        guard !exists else { return }
+        try DiveSourceFingerprint(
+            diveId: diveId,
+            deviceId: deviceId,
+            fingerprint: fingerprint,
+            sourceType: "ble"
+        ).insert(db)
     }
 }

--- a/apple/DivelogCore/Tests/CrossSourceDedupTests.swift
+++ b/apple/DivelogCore/Tests/CrossSourceDedupTests.swift
@@ -1,0 +1,375 @@
+import XCTest
+@testable import DivelogCore
+
+/// Tests for cross-source deduplication between BLE and Shearwater Cloud imports.
+final class CrossSourceDedupTests: XCTestCase {
+    var database: DivelogDatabase!
+    var diveService: DiveService!
+    var importService: DiveComputerImportService!
+
+    override func setUp() async throws {
+        database = try DivelogDatabase(path: ":memory:")
+        diveService = DiveService(database: database)
+        importService = DiveComputerImportService(database: database)
+    }
+
+    // MARK: - Shearwater-then-BLE Cross-Source Dedup
+
+    func testShearwaterThenBLEDedup() throws {
+        // Simulate a dive already imported via Shearwater Cloud:
+        // different device_id, same start_time, different fingerprint
+        let shearwaterDevice = Device(model: "Perdix", serialNumber: "SW-1234", firmwareVersion: "93")
+        try diveService.saveDevice(shearwaterDevice)
+
+        let shearwaterDive = Dive(
+            deviceId: shearwaterDevice.id,
+            startTimeUnix: 1700000000,
+            endTimeUnix: 1700003600,
+            maxDepthM: 30.0,
+            avgDepthM: 18.0,
+            bottomTimeSec: 3000,
+            fingerprint: Data([0xAA, 0xBB])  // Shearwater fingerprint
+        )
+        try diveService.saveDive(shearwaterDive)
+
+        // Also save Shearwater fingerprint in dive_source_fingerprints
+        try diveService.saveSourceFingerprints([
+            DiveSourceFingerprint(
+                diveId: shearwaterDive.id,
+                deviceId: shearwaterDevice.id,
+                fingerprint: Data([0xAA, 0xBB]),
+                sourceType: "shearwater_cloud"
+            )
+        ])
+
+        // Now import the same dive via BLE — different fingerprint, same time
+        let bleDevice = Device(model: "Perdix BLE", serialNumber: "BLE-5678", firmwareVersion: "93")
+        try diveService.saveDevice(bleDevice)
+
+        let bleParsed = ParsedDive(
+            startTimeUnix: 1700000000,  // Same start time
+            endTimeUnix: 1700003600,
+            maxDepthM: 30.0,
+            avgDepthM: 18.0,
+            bottomTimeSec: 3000,
+            fingerprint: Data([0xCC, 0xDD]),  // Different BLE fingerprint
+            samples: [
+                ParsedSample(tSec: 0, depthM: 0.0, tempC: 22.0),
+                ParsedSample(tSec: 60, depthM: 15.0, tempC: 20.0),
+            ]
+        )
+
+        // BLE import should be skipped as duplicate
+        let saved = try importService.saveImportedDive(bleParsed, deviceId: bleDevice.id)
+        XCTAssertFalse(saved)
+
+        // Only 1 dive should exist
+        let dives = try diveService.listDives()
+        XCTAssertEqual(dives.count, 1)
+
+        // BLE fingerprint should be linked to the existing dive
+        let fps = try diveService.getSourceFingerprints(diveId: shearwaterDive.id)
+        XCTAssertEqual(fps.count, 2)
+        let bleFp = fps.first(where: { $0.sourceType == "ble" })
+        XCTAssertNotNil(bleFp)
+        XCTAssertEqual(bleFp?.fingerprint, Data([0xCC, 0xDD]))
+        XCTAssertEqual(bleFp?.deviceId, bleDevice.id)
+    }
+
+    func testShearwaterThenBLEDedupWithTimestampOffset() throws {
+        // Same as above but with a small timestamp difference (within ±300s)
+        let shearwaterDevice = Device(model: "Perdix", serialNumber: "SW-1234", firmwareVersion: "93")
+        try diveService.saveDevice(shearwaterDevice)
+
+        let shearwaterDive = Dive(
+            deviceId: shearwaterDevice.id,
+            startTimeUnix: 1700000000,
+            endTimeUnix: 1700003600,
+            maxDepthM: 30.0,
+            avgDepthM: 18.0,
+            bottomTimeSec: 3000,
+            fingerprint: Data([0xAA, 0xBB])
+        )
+        try diveService.saveDive(shearwaterDive)
+
+        let bleDevice = Device(model: "Perdix BLE", serialNumber: "BLE-5678", firmwareVersion: "93")
+        try diveService.saveDevice(bleDevice)
+
+        // BLE start time is 30 seconds off — should still match
+        let bleParsed = ParsedDive(
+            startTimeUnix: 1700000030,
+            endTimeUnix: 1700003630,
+            maxDepthM: 30.0,
+            avgDepthM: 18.0,
+            bottomTimeSec: 3000,
+            fingerprint: Data([0xCC, 0xDD]),
+            samples: [ParsedSample(tSec: 0, depthM: 0.0, tempC: 22.0)]
+        )
+
+        let saved = try importService.saveImportedDive(bleParsed, deviceId: bleDevice.id)
+        XCTAssertFalse(saved)
+        XCTAssertEqual(try diveService.listDives().count, 1)
+    }
+
+    // MARK: - BLE-then-BLE Fingerprint Dedup
+
+    func testBLEThenBLEFingerprintDedup() throws {
+        let device = Device(model: "Perdix", serialNumber: "BLE-1234", firmwareVersion: "93")
+        try diveService.saveDevice(device)
+
+        let parsed = ParsedDive(
+            startTimeUnix: 1700000000,
+            endTimeUnix: 1700003600,
+            maxDepthM: 25.0,
+            avgDepthM: 15.0,
+            bottomTimeSec: 2400,
+            fingerprint: Data([0x01, 0x02, 0x03]),
+            samples: [ParsedSample(tSec: 0, depthM: 0.0, tempC: 22.0)]
+        )
+
+        // First import saves the dive
+        let firstSave = try importService.saveImportedDive(parsed, deviceId: device.id)
+        XCTAssertTrue(firstSave)
+
+        // Second import with same fingerprint should be caught by fingerprint dedup
+        let secondSave = try importService.saveImportedDive(parsed, deviceId: device.id)
+        XCTAssertFalse(secondSave)
+
+        XCTAssertEqual(try diveService.listDives().count, 1)
+    }
+
+    func testBLEFingerprintDetectedViaSourceFingerprintsTable() throws {
+        // Simulate a dive whose legacy fingerprint column differs, but the BLE
+        // fingerprint is in dive_source_fingerprints
+        let device = Device(model: "Perdix", serialNumber: "BLE-1234", firmwareVersion: "93")
+        try diveService.saveDevice(device)
+
+        let dive = Dive(
+            deviceId: device.id,
+            startTimeUnix: 1700000000,
+            endTimeUnix: 1700003600,
+            maxDepthM: 25.0,
+            avgDepthM: 15.0,
+            bottomTimeSec: 2400,
+            fingerprint: Data([0xAA, 0xBB])  // Legacy fingerprint
+        )
+        try diveService.saveDive(dive)
+
+        // Write a different fingerprint into dive_source_fingerprints
+        try diveService.saveSourceFingerprints([
+            DiveSourceFingerprint(
+                diveId: dive.id,
+                deviceId: device.id,
+                fingerprint: Data([0xCC, 0xDD]),
+                sourceType: "ble"
+            )
+        ])
+
+        // findExistingDiveByFingerprint should find via source_fingerprints table
+        let found = try importService.findExistingDiveByFingerprint(
+            fingerprint: Data([0xCC, 0xDD])
+        )
+        XCTAssertEqual(found, dive.id)
+    }
+
+    // MARK: - Genuinely Different Dives
+
+    func testDifferentDivesAreBothSaved() throws {
+        let device1 = Device(model: "Perdix", serialNumber: "SW-1234", firmwareVersion: "93")
+        let device2 = Device(model: "Perdix BLE", serialNumber: "BLE-5678", firmwareVersion: "93")
+        try diveService.saveDevice(device1)
+        try diveService.saveDevice(device2)
+
+        // Dive 1: morning dive
+        let shearwaterDive = Dive(
+            deviceId: device1.id,
+            startTimeUnix: 1700000000,
+            endTimeUnix: 1700003600,
+            maxDepthM: 30.0,
+            avgDepthM: 18.0,
+            bottomTimeSec: 3000,
+            fingerprint: Data([0xAA, 0xBB])
+        )
+        try diveService.saveDive(shearwaterDive)
+
+        // Dive 2: afternoon dive — >300s apart
+        let bleParsed = ParsedDive(
+            startTimeUnix: 1700010000,  // 10000s later (~2.7 hours)
+            endTimeUnix: 1700013600,
+            maxDepthM: 20.0,
+            avgDepthM: 12.0,
+            bottomTimeSec: 2000,
+            fingerprint: Data([0xCC, 0xDD]),
+            samples: [ParsedSample(tSec: 0, depthM: 0.0, tempC: 22.0)]
+        )
+
+        let saved = try importService.saveImportedDive(bleParsed, deviceId: device2.id)
+        XCTAssertTrue(saved)
+        XCTAssertEqual(try diveService.listDives().count, 2)
+    }
+
+    func testTimeDedupDoesNotMatchSameDevice() throws {
+        // Two dives from the SAME device with close timestamps should both be saved
+        // (time-based dedup only matches different devices)
+        let device = Device(model: "Perdix", serialNumber: "BLE-1234", firmwareVersion: "93")
+        try diveService.saveDevice(device)
+
+        let parsed1 = ParsedDive(
+            startTimeUnix: 1700000000,
+            endTimeUnix: 1700003600,
+            maxDepthM: 25.0,
+            avgDepthM: 15.0,
+            bottomTimeSec: 2400,
+            fingerprint: Data([0x01]),
+            samples: [ParsedSample(tSec: 0, depthM: 0.0, tempC: 22.0)]
+        )
+
+        let parsed2 = ParsedDive(
+            startTimeUnix: 1700000010,  // 10s later, same device
+            endTimeUnix: 1700003610,
+            maxDepthM: 20.0,
+            avgDepthM: 12.0,
+            bottomTimeSec: 2000,
+            fingerprint: Data([0x02]),  // Different fingerprint
+            samples: [ParsedSample(tSec: 0, depthM: 0.0, tempC: 21.0)]
+        )
+
+        try importService.saveImportedDive(parsed1, deviceId: device.id)
+        let saved = try importService.saveImportedDive(parsed2, deviceId: device.id)
+        XCTAssertTrue(saved)
+        XCTAssertEqual(try diveService.listDives().count, 2)
+    }
+
+    // MARK: - BLE Import Writes Source Fingerprint
+
+    func testNewBLEDiveWritesSourceFingerprint() throws {
+        let device = Device(model: "Perdix", serialNumber: "BLE-1234", firmwareVersion: "93")
+        try diveService.saveDevice(device)
+
+        let parsed = ParsedDive(
+            startTimeUnix: 1700000000,
+            endTimeUnix: 1700003600,
+            maxDepthM: 25.0,
+            avgDepthM: 15.0,
+            bottomTimeSec: 2400,
+            fingerprint: Data([0xDE, 0xAD]),
+            samples: [ParsedSample(tSec: 0, depthM: 0.0, tempC: 22.0)]
+        )
+
+        try importService.saveImportedDive(parsed, deviceId: device.id)
+
+        let dives = try diveService.listDives()
+        XCTAssertEqual(dives.count, 1)
+
+        // Verify dive_source_fingerprints was written
+        let fps = try diveService.getSourceFingerprints(diveId: dives[0].id)
+        XCTAssertEqual(fps.count, 1)
+        XCTAssertEqual(fps[0].fingerprint, Data([0xDE, 0xAD]))
+        XCTAssertEqual(fps[0].sourceType, "ble")
+        XCTAssertEqual(fps[0].deviceId, device.id)
+    }
+
+    func testDiveWithoutFingerprintDoesNotWriteSourceFingerprint() throws {
+        let device = Device(model: "Perdix", serialNumber: "BLE-1234", firmwareVersion: "93")
+        try diveService.saveDevice(device)
+
+        let parsed = ParsedDive(
+            startTimeUnix: 1700000000,
+            endTimeUnix: 1700003600,
+            maxDepthM: 20.0,
+            avgDepthM: 12.0,
+            bottomTimeSec: 2000
+            // No fingerprint
+        )
+
+        try importService.saveImportedDive(parsed, deviceId: device.id)
+
+        let dives = try diveService.listDives()
+        XCTAssertEqual(dives.count, 1)
+
+        // No source fingerprint should be written
+        let fps = try diveService.getSourceFingerprints(diveId: dives[0].id)
+        XCTAssertEqual(fps.count, 0)
+    }
+
+    // MARK: - Time Boundary Tests
+
+    func testTimeDedupAtExactBoundary() throws {
+        let shearwaterDevice = Device(model: "Perdix", serialNumber: "SW-1234", firmwareVersion: "93")
+        let bleDevice = Device(model: "Perdix BLE", serialNumber: "BLE-5678", firmwareVersion: "93")
+        try diveService.saveDevice(shearwaterDevice)
+        try diveService.saveDevice(bleDevice)
+
+        let shearwaterDive = Dive(
+            deviceId: shearwaterDevice.id,
+            startTimeUnix: 1700000000,
+            endTimeUnix: 1700003600,
+            maxDepthM: 30.0,
+            avgDepthM: 18.0,
+            bottomTimeSec: 3000
+        )
+        try diveService.saveDive(shearwaterDive)
+
+        // Exactly 300s offset — should still match (ABS <= 300)
+        let bleParsedAtBoundary = ParsedDive(
+            startTimeUnix: 1700000300,
+            endTimeUnix: 1700003900,
+            maxDepthM: 30.0,
+            avgDepthM: 18.0,
+            bottomTimeSec: 3000,
+            fingerprint: Data([0xEE, 0xFF]),
+            samples: [ParsedSample(tSec: 0, depthM: 0.0, tempC: 22.0)]
+        )
+        let savedBoundary = try importService.saveImportedDive(bleParsedAtBoundary, deviceId: bleDevice.id)
+        XCTAssertFalse(savedBoundary, "Dive at exactly 300s offset should be deduped")
+
+        // 301s offset — should NOT match
+        let bleParsedBeyond = ParsedDive(
+            startTimeUnix: 1700000301,
+            endTimeUnix: 1700003901,
+            maxDepthM: 30.0,
+            avgDepthM: 18.0,
+            bottomTimeSec: 3000,
+            fingerprint: Data([0x11, 0x22]),
+            samples: [ParsedSample(tSec: 0, depthM: 0.0, tempC: 22.0)]
+        )
+        let savedBeyond = try importService.saveImportedDive(bleParsedBeyond, deviceId: bleDevice.id)
+        XCTAssertTrue(savedBeyond, "Dive at 301s offset should be saved as new")
+    }
+
+    // MARK: - Duplicate Fingerprint Linking Is Idempotent
+
+    func testLinkingFingerprintTwiceDoesNotDuplicate() throws {
+        let shearwaterDevice = Device(model: "Perdix", serialNumber: "SW-1234", firmwareVersion: "93")
+        let bleDevice = Device(model: "Perdix BLE", serialNumber: "BLE-5678", firmwareVersion: "93")
+        try diveService.saveDevice(shearwaterDevice)
+        try diveService.saveDevice(bleDevice)
+
+        let shearwaterDive = Dive(
+            deviceId: shearwaterDevice.id,
+            startTimeUnix: 1700000000,
+            endTimeUnix: 1700003600,
+            maxDepthM: 30.0,
+            avgDepthM: 18.0,
+            bottomTimeSec: 3000
+        )
+        try diveService.saveDive(shearwaterDive)
+
+        let bleParsed = ParsedDive(
+            startTimeUnix: 1700000000,
+            endTimeUnix: 1700003600,
+            maxDepthM: 30.0,
+            avgDepthM: 18.0,
+            bottomTimeSec: 3000,
+            fingerprint: Data([0xCC, 0xDD]),
+            samples: [ParsedSample(tSec: 0, depthM: 0.0, tempC: 22.0)]
+        )
+
+        // Import twice — fingerprint should only be linked once
+        try importService.saveImportedDive(bleParsed, deviceId: bleDevice.id)
+        try importService.saveImportedDive(bleParsed, deviceId: bleDevice.id)
+
+        let fps = try diveService.getSourceFingerprints(diveId: shearwaterDive.id)
+        XCTAssertEqual(fps.count, 1, "Fingerprint should only be linked once")
+    }
+}

--- a/apple/DivelogCore/Tests/DiveComputerTests.swift
+++ b/apple/DivelogCore/Tests/DiveComputerTests.swift
@@ -142,7 +142,7 @@ final class DiveComputerTests: XCTestCase {
 
     // MARK: - Fingerprint Duplicate Detection
 
-    func testIsDuplicateFingerprint() throws {
+    func testFindExistingDiveByFingerprint() throws {
         let device = Device(model: "Test", serialNumber: "SN", firmwareVersion: "1.0")
         try diveService.saveDevice(device)
 
@@ -158,11 +158,13 @@ final class DiveComputerTests: XCTestCase {
         )
         try diveService.saveDive(dive)
 
-        // Same fingerprint should be detected as duplicate
-        XCTAssertTrue(try importService.isDuplicate(fingerprint: fingerprint))
+        // Same fingerprint should return the existing dive ID
+        let found = try importService.findExistingDiveByFingerprint(fingerprint: fingerprint)
+        XCTAssertEqual(found, dive.id)
 
-        // Different fingerprint should not be duplicate
-        XCTAssertFalse(try importService.isDuplicate(fingerprint: Data([0xCA, 0xFE])))
+        // Different fingerprint should return nil
+        let notFound = try importService.findExistingDiveByFingerprint(fingerprint: Data([0xCA, 0xFE]))
+        XCTAssertNil(notFound)
     }
 
     // MARK: - Last Fingerprint Ordering


### PR DESCRIPTION
## Summary

- Adds **time-based secondary dedup** to `DiveComputerImportService.saveImportedDive()`: when a BLE fingerprint doesn't match any existing fingerprint, checks if a dive with the same `start_time_unix` (±300s) already exists from a different device
- Refactors `isDuplicate()` → `findExistingDiveByFingerprint()` to check **both** the legacy `dives.fingerprint` column and `dive_source_fingerprints` table
- BLE imports now **write to `dive_source_fingerprints`** so future imports are caught by fingerprint dedup
- When a cross-source match is found, the BLE fingerprint is linked to the existing dive (no duplicate row created)

## Test plan

- [x] Shearwater-then-BLE dedup: dive imported via Shearwater Cloud, then same dive via BLE (same start time, different fingerprint) → BLE import skipped, BLE fingerprint linked
- [x] Shearwater-then-BLE with timestamp offset (30s) → still deduped
- [x] BLE-then-BLE fingerprint dedup: re-import same BLE dive → skipped
- [x] Fingerprint detected via `dive_source_fingerprints` table (not just legacy column)
- [x] Genuinely different dives (>300s apart) both saved
- [x] Time-based dedup does NOT match same device (only cross-source)
- [x] New BLE dive writes `DiveSourceFingerprint` record
- [x] Dive without fingerprint does not write source fingerprint
- [x] Time boundary: exactly 300s matches, 301s does not
- [x] Linking fingerprint twice is idempotent (no duplicate records)
- [x] All existing tests pass (`swift test` + `make lint`)

Fixes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)