### PR TITLE
Add deco ceiling overlay to depth profile chart

### DIFF
--- a/apple/DivelogCore/Sources/Database/DivelogDatabase.swift
+++ b/apple/DivelogCore/Sources/Database/DivelogDatabase.swift
@@ -359,6 +359,16 @@ public final class DivelogDatabase: Sendable {
             }
         }
 
+        migrator.registerMigration("011_add_max_ceiling") { db in
+            try db.execute(sql: """
+                ALTER TABLE dives ADD COLUMN max_ceiling_m REAL;
+
+                UPDATE dives SET max_ceiling_m = (
+                    SELECT MAX(ceiling_m) FROM samples WHERE samples.dive_id = dives.id
+                );
+            """)
+        }
+
         try migrator.migrate(dbQueue)
     }
 }

--- a/apple/DivelogCore/Sources/Models/Dive.swift
+++ b/apple/DivelogCore/Sources/Models/Dive.swift
@@ -39,6 +39,7 @@ public struct Dive: Identifiable, Equatable, Hashable, Sendable {
     public var lon: Double?
     public var groupId: String?
     public var environment: String?
+    public var maxCeilingM: Float?
     public var visibility: String?
     public var weather: String?
 
@@ -75,6 +76,7 @@ public struct Dive: Identifiable, Equatable, Hashable, Sendable {
         lat: Double? = nil,
         lon: Double? = nil,
         groupId: String? = nil,
+        maxCeilingM: Float? = nil,
         environment: String? = nil,
         visibility: String? = nil,
         weather: String? = nil
@@ -111,6 +113,7 @@ public struct Dive: Identifiable, Equatable, Hashable, Sendable {
         self.lat = lat
         self.lon = lon
         self.groupId = groupId
+        self.maxCeilingM = maxCeilingM
         self.environment = environment
         self.visibility = visibility
         self.weather = weather
@@ -155,6 +158,7 @@ extension Dive: Codable, FetchableRecord, PersistableRecord {
         case lat
         case lon
         case groupId = "group_id"
+        case maxCeilingM = "max_ceiling_m"
         case environment
         case visibility
         case weather

--- a/apple/DivelogCore/Sources/Services/DiveDataMapper.swift
+++ b/apple/DivelogCore/Sources/Services/DiveDataMapper.swift
@@ -203,6 +203,13 @@ public enum DiveDataMapper {
     /// Converts a `ParsedDive` into a `Dive`, its `[DiveSample]`, and `[GasMix]`.
     public static func toDive(_ parsed: ParsedDive, deviceId: String) -> (Dive, [DiveSample], [GasMix]) {
         let diveId = UUID().uuidString
+        let maxCeiling: Float? = {
+            var maxVal: Float = 0
+            for s in parsed.samples {
+                if let c = s.ceilingM, c > maxVal { maxVal = c }
+            }
+            return maxVal > 0 ? maxVal : nil
+        }()
         let dive = Dive(
             id: diveId,
             deviceId: deviceId,
@@ -226,7 +233,8 @@ public enum DiveDataMapper {
             salinity: parsed.salinity,
             surfacePressureBar: parsed.surfacePressureBar,
             lat: parsed.lat,
-            lon: parsed.lon
+            lon: parsed.lon,
+            maxCeilingM: maxCeiling
         )
 
         let samples = parsed.samples.map { s in

--- a/apple/DivelogCore/Sources/Services/ShearwaterCloudImportService.swift
+++ b/apple/DivelogCore/Sources/Services/ShearwaterCloudImportService.swift
@@ -461,6 +461,17 @@ public final class ShearwaterCloudImportService: Sendable {
                 return nil
             }()
 
+            // Max ceiling across all computers' samples
+            let mergedMaxCeiling: Float? = {
+                var maxVal: Float = 0
+                for pr in parseResults {
+                    for s in pr.parsedInfo.samples {
+                        if let c = s.ceilingM, c > maxVal { maxVal = c }
+                    }
+                }
+                return maxVal > 0 ? maxVal : nil
+            }()
+
             let diveId = UUID().uuidString
             let dive = Dive(
                 id: diveId,
@@ -487,6 +498,7 @@ public final class ShearwaterCloudImportService: Sendable {
                 lat: mergedLat,
                 lon: mergedLon,
                 groupId: groupId,
+                maxCeilingM: mergedMaxCeiling,
                 environment: mergedEnvironment,
                 visibility: mergedVisibility,
                 weather: mergedWeather


### PR DESCRIPTION
## Summary
- Auto-renders a red shaded `AreaMark` from surface down to ceiling depth on any dive with ceiling data — no toggle chip, always visible on deco dives
- Scrub tooltip shows **CEIL** (ceiling depth) and **TTS** (time to surface) in red when hovering over deco portions
- Precomputed + downsampled ceiling data (~300 points, no smoothing — ceiling is step-wise)
- Accessibility label includes max ceiling info for deco dives
- Chart body refactored into `@ChartContentBuilder` helpers to stay within Swift type-checker limits

Fixes #3

## Test plan
- [x] Open a deco dive → red shaded ceiling area visible from surface down to ceiling depth
- [x] Scrub over deco portion → tooltip shows depth + CEIL + TTS in red
- [x] Scrub over non-deco portion of same dive → no CEIL/TTS in tooltip
- [x] Open a rec (non-deco) dive → no ceiling shading visible
- [x] Fullscreen chart → ceiling area scales correctly
- [x] Temperature + ceiling coexist — orange temp line + red ceiling region
- [x] VoiceOver reads "Deco ceiling shown, maximum ceiling X.Xm"

🤖 Generated with [Claude Code](https://claude.com/claude-code)