### PR TITLE
Fix ceiling close point, @MainActor AppDelegate, tooltip comment

### DIFF
--- a/Profundum/Profundum/ProfundumApp.swift
+++ b/Profundum/Profundum/ProfundumApp.swift
@@ -3,6 +3,7 @@ import DivelogCore
 import SwiftUI
 
 #if os(iOS)
+@MainActor
 class AppDelegate: NSObject, UIApplicationDelegate {
     /// Orientation lock — views can override to force landscape, etc.
     static var orientationLock: UIInterfaceOrientationMask = .all


### PR DESCRIPTION
## Summary
Follow-up fixes from PR #64 review:

- **Ceiling close point bug**: The final ceiling point read raw `samples[].ceilingM` instead of `smoothedCeiling[]`, bypassing the rolling-max smoothing and potentially creating a visual discontinuity at end of deco
- **@MainActor on AppDelegate**: Future-proofs `orientationLock` static var for strict concurrency checking
- **Tooltip comment**: Clarifies that `nearestCeilingDisplay` intentionally shows the raw dive computer value (what the diver saw on their wrist), not the smoothed chart display value

## Test plan
- [x] Verify deco dive chart renders cleanly at the end of the ceiling area (no discontinuity)
- [x] Verify fullscreen orientation lock still works on iOS
- [x] Verify ceiling tooltip still shows correct values when scrubbing

🤖 Generated with [Claude Code](https://claude.com/claude-code)