### PR TITLE
Add computed Δ+5 TTS property to DiveSample

### DIFF
--- a/apple/DivelogCore/Sources/Models/DiveSample.swift
+++ b/apple/DivelogCore/Sources/Models/DiveSample.swift
@@ -25,6 +25,14 @@ public struct DiveSample: Identifiable, Equatable, Sendable {
     public var gasmixIndex: Int?
     public var atPlusFiveTtsMin: Int?
 
+    /// Δ+5: projected change in TTS if diver stays 5 more minutes at current depth.
+    /// Positive = accumulating deco, negative = clearing deco, nil = no data.
+    public var deltaFiveTtsMin: Int? {
+        guard let atPlusFive = atPlusFiveTtsMin else { return nil }
+        guard let tts = ttsSec else { return atPlusFive }
+        return atPlusFive - (tts / 60)
+    }
+
     public init(
         id: String = UUID().uuidString,
         diveId: String,

--- a/apple/DivelogCore/Tests/DiveComputerTests.swift
+++ b/apple/DivelogCore/Tests/DiveComputerTests.swift
@@ -862,4 +862,42 @@ final class DiveComputerTests: XCTestCase {
         let mixes = try diveService.getGasMixes(diveId: dive.id)
         XCTAssertEqual(mixes.count, 2, "Read-time dedup should remove duplicates")
     }
+
+    // MARK: - DiveSample.deltaFiveTtsMin Tests
+
+    func testDeltaFiveBothPresentPositive() {
+        let sample = DiveSample(diveId: "d1", tSec: 0, depthM: 30, tempC: 20,
+                                ttsSec: 600, atPlusFiveTtsMin: 15)
+        XCTAssertEqual(sample.deltaFiveTtsMin, 5)
+    }
+
+    func testDeltaFiveBothPresentNegative() {
+        let sample = DiveSample(diveId: "d1", tSec: 0, depthM: 30, tempC: 20,
+                                ttsSec: 480, atPlusFiveTtsMin: 3)
+        XCTAssertEqual(sample.deltaFiveTtsMin, -5)
+    }
+
+    func testDeltaFiveBothPresentZero() {
+        let sample = DiveSample(diveId: "d1", tSec: 0, depthM: 30, tempC: 20,
+                                ttsSec: 600, atPlusFiveTtsMin: 10)
+        XCTAssertEqual(sample.deltaFiveTtsMin, 0)
+    }
+
+    func testDeltaFiveAtPlusFiveNil() {
+        let sample = DiveSample(diveId: "d1", tSec: 0, depthM: 30, tempC: 20,
+                                ttsSec: 600, atPlusFiveTtsMin: nil)
+        XCTAssertNil(sample.deltaFiveTtsMin)
+    }
+
+    func testDeltaFiveTtsNilAtPlusFivePresent() {
+        let sample = DiveSample(diveId: "d1", tSec: 0, depthM: 30, tempC: 20,
+                                ttsSec: nil, atPlusFiveTtsMin: 12)
+        XCTAssertEqual(sample.deltaFiveTtsMin, 12)
+    }
+
+    func testDeltaFiveBothNil() {
+        let sample = DiveSample(diveId: "d1", tSec: 0, depthM: 30, tempC: 20,
+                                ttsSec: nil, atPlusFiveTtsMin: nil)
+        XCTAssertNil(sample.deltaFiveTtsMin)
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `deltaFiveTtsMin` computed property to `DiveSample` that derives Δ+5 from existing `atPlusFiveTtsMin` and `ttsSec` fields
- Pure derivation — no storage or migration needed
- 6 unit tests covering all nil/value combinations (both present positive/negative/zero, @+5 nil, TTS nil, both nil)

Closes #73

## Test plan
- [x] `make lint` passes (cargo fmt, clippy, swiftlint — 0 violations)
- [x] `xcodebuild build` succeeds
- [x] `xcodebuild test` passes (all 6 new deltaFive tests + existing suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)