### PR TITLE
Fix chart cache invalidation on device switch (#98)

### DIFF
--- a/Profundum/Profundum/Views/DepthProfileChart.swift
+++ b/Profundum/Profundum/Views/DepthProfileChart.swift
@@ -711,11 +711,6 @@ struct DepthProfileChart: View {
     @State private var chartData: DepthProfileChartData?
     @State private var selectedTime: Float?
 
-    /// Lightweight identity key for sample data — avoids deep array comparison.
-    private var sampleCacheKey: String {
-        "\(samples.first?.id ?? "")-\(samples.last?.id ?? "")-\(samples.count)"
-    }
-
     private var selectedPoint: DepthDataPoint? {
         guard let selectedTime, let data = chartData else { return nil }
         return data.nearestDepthPoint(to: selectedTime)
@@ -864,7 +859,7 @@ struct DepthProfileChart: View {
         .onAppear {
             buildChartData()
         }
-        .onChange(of: sampleCacheKey) { _, _ in
+        .onChange(of: samples.cacheKey) { _, _ in
             buildChartData()
         }
         .onChange(of: depthUnit) { _, _ in

--- a/apple/DivelogCore/Sources/Models/DiveSample.swift
+++ b/apple/DivelogCore/Sources/Models/DiveSample.swift
@@ -115,3 +115,14 @@ extension DiveSample: Codable, FetchableRecord, PersistableRecord {
 extension DiveSample {
     static let dive = belongsTo(Dive.self)
 }
+
+// MARK: - Cache Key
+
+extension Array where Element == DiveSample {
+    /// Lightweight O(1) identity key for change detection — avoids deep array comparison.
+    /// Uses first/last sample IDs plus count, which changes on any realistic data swap
+    /// (device switch, reload, append/remove). Assumes sample IDs are unique and stable.
+    public var cacheKey: String {
+        "\(first?.id ?? "")-\(last?.id ?? "")-\(count)"
+    }
+}

--- a/apple/DivelogCore/Tests/SampleCacheKeyTests.swift
+++ b/apple/DivelogCore/Tests/SampleCacheKeyTests.swift
@@ -1,0 +1,122 @@
+import XCTest
+@testable import DivelogCore
+
+final class SampleCacheKeyTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeSample(
+        id: String = UUID().uuidString,
+        diveId: String = "dive-1",
+        deviceId: String? = nil,
+        tSec: Int32 = 0
+    ) -> DiveSample {
+        DiveSample(
+            id: id,
+            diveId: diveId,
+            deviceId: deviceId,
+            tSec: tSec,
+            depthM: 30.0,
+            tempC: 20.0
+        )
+    }
+
+    // MARK: - Basic behavior
+
+    func testEmptyArrayCacheKey() {
+        let samples: [DiveSample] = []
+        XCTAssertEqual(samples.cacheKey, "--0")
+    }
+
+    func testSingleSampleCacheKey() {
+        let sample = makeSample(id: "abc")
+        XCTAssertEqual([sample].cacheKey, "abc-abc-1")
+    }
+
+    func testStableForSameArray() {
+        let samples = [
+            makeSample(id: "a", tSec: 0),
+            makeSample(id: "b", tSec: 10),
+            makeSample(id: "c", tSec: 20),
+        ]
+        XCTAssertEqual(samples.cacheKey, samples.cacheKey)
+    }
+
+    // MARK: - Device switch detection (primary use case)
+
+    func testDifferentDevicesSameCountProduceDifferentKeys() {
+        let deviceA = [
+            makeSample(id: "a1", deviceId: "shearwater", tSec: 0),
+            makeSample(id: "a2", deviceId: "shearwater", tSec: 10),
+            makeSample(id: "a3", deviceId: "shearwater", tSec: 20),
+        ]
+        let deviceB = [
+            makeSample(id: "b1", deviceId: "garmin", tSec: 0),
+            makeSample(id: "b2", deviceId: "garmin", tSec: 10),
+            makeSample(id: "b3", deviceId: "garmin", tSec: 20),
+        ]
+        XCTAssertEqual(deviceA.count, deviceB.count)
+        XCTAssertNotEqual(deviceA.cacheKey, deviceB.cacheKey)
+    }
+
+    // MARK: - Count changes
+
+    func testDifferentCountProducesDifferentKey() {
+        let two = [
+            makeSample(id: "a", tSec: 0),
+            makeSample(id: "b", tSec: 10),
+        ]
+        let three = [
+            makeSample(id: "a", tSec: 0),
+            makeSample(id: "x", tSec: 5),
+            makeSample(id: "b", tSec: 10),
+        ]
+        // Same first and last IDs, different count
+        XCTAssertNotEqual(two.cacheKey, three.cacheKey)
+    }
+
+    // MARK: - Interior-only changes (known limitation)
+
+    func testInteriorChangeWithSameBoundariesNotDetected() {
+        let original = [
+            makeSample(id: "a", tSec: 0),
+            makeSample(id: "b", tSec: 10),
+            makeSample(id: "c", tSec: 20),
+        ]
+        let modified = [
+            makeSample(id: "a", tSec: 0),
+            makeSample(id: "d", tSec: 15),  // different interior sample
+            makeSample(id: "c", tSec: 20),
+        ]
+        // Documented limitation: interior-only changes are not detected.
+        // This is acceptable because device switches always change boundary IDs.
+        XCTAssertEqual(original.cacheKey, modified.cacheKey,
+                       "Interior changes are intentionally not detected by cacheKey")
+    }
+
+    // MARK: - Edge cases
+
+    func testAppendChangesKey() {
+        let before = [
+            makeSample(id: "a", tSec: 0),
+            makeSample(id: "b", tSec: 10),
+        ]
+        let after = before + [makeSample(id: "c", tSec: 20)]
+        XCTAssertNotEqual(before.cacheKey, after.cacheKey)
+    }
+
+    func testPrependChangesKey() {
+        let before = [
+            makeSample(id: "b", tSec: 10),
+            makeSample(id: "c", tSec: 20),
+        ]
+        let after = [makeSample(id: "a", tSec: 0)] + before
+        XCTAssertNotEqual(before.cacheKey, after.cacheKey)
+    }
+
+    func testCompleteReplacementChangesKey() {
+        let setA = [makeSample(id: "x")]
+        let setB = [makeSample(id: "y")]
+        XCTAssertNotEqual(setA.cacheKey, setB.cacheKey)
+    }
+}


### PR DESCRIPTION
## Summary
- Replace `onChange(of: samples.count)` with an identity-based cache key (`first.id-last.id-count`) so the depth profile chart rebuilds when switching between devices with equal sample counts
- Replace `onChange(of: gasMixes.count)` with full `gasMixes` equality for correctness (trivially cheap with 1–4 elements)

## Details
`DepthProfileChart` caches computed `chartData` in a `@State` variable and rebuilds via `onChange`. The trigger `onChange(of: samples.count)` only detects changes in array length — when the device picker (PR #97) switches between two computers with equal sample counts, the chart data stays stale. The fix uses a lightweight O(1) cache key composed of the first/last sample IDs and the count, which changes on any realistic data swap.

## Test plan
- [ ] Open a multi-computer dive where both devices have equal sample counts
- [ ] Switch between devices in the picker → chart should update immediately
- [ ] Verify chart still rebuilds correctly on: initial load, unit changes, SurfGF toggle
- [ ] Verify fullscreen chart also reflects device switch

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)