### PR TITLE
Fix depth profile chart excessive right-side padding

### DIFF
--- a/Profundum/Profundum/Views/DepthProfileChart.swift
+++ b/Profundum/Profundum/Views/DepthProfileChart.swift
@@ -1097,6 +1097,7 @@ struct DepthProfileChart: View {
             scrubContent
         }
         .chartYScale(domain: data.domainMin ... data.domainMax)
+        .chartXScale(domain: 0 ... data.totalMinutes)
         .chartLegend(.hidden)
         .chartXAxis {
             AxisMarks(values: .automatic) { value in


### PR DESCRIPTION
## Summary
- Add explicit `.chartXScale(domain: 0 ... data.totalMinutes)` to the depth profile chart
- Without it, Swift Charts auto-scales the X-axis with ~5-10% padding on each side, leaving noticeable empty space after dive data ends
- Matches the existing `.chartYScale(domain:)` that already controls the Y-axis domain

Closes #95

## Test plan
- [ ] Open a dive detail view and confirm the depth profile chart fills the width with minimal right padding
- [ ] Verify scrub interaction still works correctly across the full chart width
- [ ] Check multi-computer dives (device picker) still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)