### PR TITLE
Add missing gf_high=0 validation test for coverage

### DIFF
--- a/core/src/deco/profile_generator.rs
+++ b/core/src/deco/profile_generator.rs
@@ -646,9 +646,17 @@ mod tests {
     }
 
     #[test]
-    fn test_zero_gf_rejected() {
+    fn test_zero_gf_low_rejected() {
         let mut params = air_params(30.0, 600);
         params.gf_low = Some(0);
+        let result = generate_dive_profile(params);
+        assert!(matches!(result, Err(DecoSimError::InvalidParam { .. })));
+    }
+
+    #[test]
+    fn test_zero_gf_high_rejected() {
+        let mut params = air_params(30.0, 600);
+        params.gf_high = Some(0);
         let result = generate_dive_profile(params);
         assert!(matches!(result, Err(DecoSimError::InvalidParam { .. })));
     }


### PR DESCRIPTION
## Summary
- Split `test_zero_gf_rejected` into `test_zero_gf_low_rejected` + `test_zero_gf_high_rejected` to cover the `gf_high == 0` rejection branch

Fixes 3 of the uncovered lines reported by Codecov on #156.

Remaining 2 uncovered production lines are defensive guards that can't be triggered through the public API:
- Line 511: surface-ensure fallback (ascend_segment always reaches surface)
- Line 528: early-return when already at target depth (no engine produces this case)

## Test plan
- [x] `cargo test` — 283 tests pass
- [x] `cargo llvm-cov` — 98.6% production coverage (5 → 2 uncovered production lines, both defensive guards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)