### PR TITLE
Add actual-dive replay mode using recorded samples (PRO-61)

### DIFF
--- a/Profundum/Profundum/Views/DepthProfileChart.swift
+++ b/Profundum/Profundum/Views/DepthProfileChart.swift
@@ -273,29 +273,8 @@ struct DepthProfileChartData {
 
         // Bühlmann sim overlay (lazy — only run when SurfGF or GF99 overlay is active)
         if needsBuhlmannSim {
-            let sampleInputs = samples.map { s in
-                SampleInput(
-                    tSec: s.tSec,
-                    depthM: s.depthM,
-                    tempC: s.tempC,
-                    setpointPpo2: s.setpointPpo2,
-                    ceilingM: s.ceilingM,
-                    gf99: s.gf99,
-                    gasmixIndex: s.gasmixIndex.map { Int32($0) },
-                    ppo2: s.ppo2_1 ?? s.setpointPpo2,
-                    ttsSec: s.ttsSec.map { Int32($0) },
-                    ndlSec: s.ndlSec.map { Int32($0) },
-                    decoStopDepthM: s.decoStopDepthM,
-                    atPlusFiveTtsMin: s.atPlusFiveTtsMin.map { Int32($0) }
-                )
-            }
-            let gasMixInputs = gasMixes.map { mix in
-                GasMixInput(
-                    mixIndex: Int32(mix.mixIndex),
-                    o2Fraction: Double(mix.o2Fraction),
-                    heFraction: Double(mix.heFraction)
-                )
-            }
+            let sampleInputs = samples.toSampleInputs()
+            let gasMixInputs = gasMixes.toGasMixInputs()
             let simResult = DivelogCompute.computeSurfaceGf(
                 samples: sampleInputs,
                 gasMixes: gasMixInputs

--- a/Profundum/Profundum/Views/ReplayProfileSheet.swift
+++ b/Profundum/Profundum/Views/ReplayProfileSheet.swift
@@ -10,6 +10,15 @@ struct ReplayProfileSheet: View {
     let stats: DiveStats?
     let samples: [DiveSample]
 
+    // MARK: - Mode
+
+    enum ReplayMode: String, CaseIterable {
+        case actualDive = "Actual Dive"
+        case whatIfPlanning = "What-If Planning"
+    }
+
+    @State private var replayMode: ReplayMode = .actualDive
+
     // MARK: - Form state
 
     @State private var targetDepthText: String = ""
@@ -26,6 +35,7 @@ struct ReplayProfileSheet: View {
     @State private var diluentO2Percent: Int = 21
     @State private var diluentHePercent: Int = 35
     @State private var setpointText: String = "1.3"
+    @State private var originalSetpointText: String = ""
     @FocusState private var focusedField: Bool
     @State private var surfacePressureText: String = "1.01325"
     @State private var tempText: String = ""
@@ -34,7 +44,12 @@ struct ReplayProfileSheet: View {
 
     // MARK: - Result state
 
-    @State private var result: ProfileGenResult?
+    enum ReplayResult {
+        case synthetic(ProfileGenResult)
+        case actual(DecoSimResult)
+    }
+
+    @State private var result: ReplayResult?
     @State private var errorMessage: String?
     @State private var isGenerating = false
 
@@ -44,7 +59,10 @@ struct ReplayProfileSheet: View {
         NavigationStack {
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
-                    depthAndTimeSection
+                    modePicker
+                    if replayMode == .whatIfPlanning {
+                        depthAndTimeSection
+                    }
                     decoModelSection
                     if selectedModel == .buhlmannZhl16c {
                         gradientFactorsSection
@@ -53,7 +71,7 @@ struct ReplayProfileSheet: View {
                     }
                     if dive.isCcr {
                         ccrDiluentSection
-                    } else {
+                    } else if replayMode == .whatIfPlanning {
                         gasPlanSection
                     }
                     advancedSection
@@ -376,6 +394,29 @@ struct ReplayProfileSheet: View {
         }
     }
 
+    private var modePicker: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Picker("Mode", selection: $replayMode) {
+                ForEach(ReplayMode.allCases, id: \.self) { mode in
+                    Text(mode.rawValue).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+            .disabled(samples.isEmpty)
+            .accessibilityLabel("Replay mode")
+
+            if replayMode == .actualDive {
+                Text("Runs the deco algorithm on your actual recorded dive profile.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            } else {
+                Text("Generates a synthetic square profile from the parameters below.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+
     private var generateButton: some View {
         Button {
             generate()
@@ -385,13 +426,13 @@ struct ReplayProfileSheet: View {
                     ProgressView()
                         .controlSize(.small)
                 }
-                Text("Generate Profile")
+                Text(replayMode == .actualDive ? "Compute Deco Analysis" : "Generate Profile")
             }
             .frame(maxWidth: .infinity)
         }
         .buttonStyle(.borderedProminent)
         .disabled(isGenerating)
-        .accessibilityLabel("Generate dive profile")
+        .accessibilityLabel(replayMode == .actualDive ? "Compute deco analysis" : "Generate dive profile")
         .accessibilityHint("Runs the decompression simulation with current parameters")
     }
 
@@ -408,16 +449,40 @@ struct ReplayProfileSheet: View {
         .accessibilityLabel("Error: \(message)")
     }
 
-    private func resultSummary(_ result: ProfileGenResult) -> some View {
+    private func resultSummary(_ result: ReplayResult) -> some View {
+        let extracted = extractResultData(result)
+        return resultGrid(
+            decoResult: extracted.decoResult,
+            totalTimeSec: extracted.totalTimeSec,
+            decoTimeSec: extracted.decoTimeSec
+        )
+    }
+
+    // swiftlint:disable:next line_length
+    private func extractResultData(_ result: ReplayResult) -> (decoResult: DecoSimResult, totalTimeSec: Int32, decoTimeSec: Int32) {
+        switch result {
+        case .synthetic(let profileResult):
+            return (
+                profileResult.decoResult,
+                profileResult.totalTimeSec,
+                profileResult.totalTimeSec - profileResult.bottomEndTSec
+            )
+        case .actual(let simResult):
+            let totalTime = samples.last.map { $0.tSec } ?? 0
+            return (simResult, totalTime, simResult.totalDecoTimeSec)
+        }
+    }
+
+    private func resultGrid(decoResult: DecoSimResult, totalTimeSec: Int32, decoTimeSec: Int32) -> some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Result")
                 .font(.headline)
 
-            if result.decoResult.truncated {
+            if decoResult.truncated {
                 HStack {
                     Image(systemName: "exclamationmark.triangle.fill")
                         .foregroundColor(.orange)
-                    Text("Profile was truncated — ascent may exceed safe limits with these parameters.")
+                    Text("Profile was truncated — results may exceed safe limits with these parameters.")
                         .font(.callout)
                 }
                 .padding(8)
@@ -430,34 +495,32 @@ struct ReplayProfileSheet: View {
             LazyVGrid(columns: columns, spacing: 12) {
                 StatCard(
                     title: "Total Time",
-                    value: "\(result.totalTimeSec / 60) min"
+                    value: "\(totalTimeSec / 60) min"
                 )
                 StatCard(
-                    title: "Deco Time",
-                    value: "\(decoTimeSec(result) / 60) min"
-                )
-                StatCard(
-                    title: "Stops",
-                    value: "\(result.decoResult.decoStops.count)"
+                    title: "Deco Stops",
+                    value: "\(decoTimeSec / 60) min"
                 )
                 StatCard(
                     title: "Max Ceiling",
                     value: UnitFormatter.formatDepth(
-                        result.decoResult.maxCeilingM,
+                        decoResult.maxCeilingM,
                         unit: appState.depthUnit
                     )
                 )
                 StatCard(
                     title: "Max GF99",
-                    value: String(format: "%.0f%%", result.decoResult.maxGf99)
+                    value: String(format: "%.0f%%", decoResult.maxGf99)
                 )
                 StatCard(
                     title: "Max TTS",
-                    value: "\(result.decoResult.maxTtsSec / 60) min"
+                    value: "\(decoResult.maxTtsSec / 60) min"
+                )
+                StatCard(
+                    title: "Model",
+                    value: decoResult.model == .buhlmannZhl16c ? "Bühlmann" : "Thalmann"
                 )
             }
-
-            // Phase 4 placeholder: animated chart will go here
         }
     }
 
@@ -482,10 +545,6 @@ struct ReplayProfileSheet: View {
         } else {
             return "Nitrox \(o2)"
         }
-    }
-
-    private func decoTimeSec(_ r: ProfileGenResult) -> Int32 {
-        r.totalTimeSec - r.bottomEndTSec
     }
 
     /// Compute ascent rate from the transit phase only (bottom_end → deco_start).
@@ -514,6 +573,9 @@ struct ReplayProfileSheet: View {
     // MARK: - Prefill
 
     private func prefill() {
+        // Default to actual dive mode when samples are available
+        replayMode = samples.isEmpty ? .whatIfPlanning : .actualDive
+
         let du = appState.depthUnit
         let tu = appState.temperatureUnit
 
@@ -582,6 +644,7 @@ struct ReplayProfileSheet: View {
         if dive.isCcr {
             let maxSp = samples.compactMap(\.setpointPpo2).max() ?? 1.3
             setpointText = String(format: "%.1f", maxSp)
+            originalSetpointText = setpointText
         }
 
         // Advanced defaults in display units
@@ -672,6 +735,38 @@ struct ReplayProfileSheet: View {
         result = nil
         isGenerating = true
 
+        switch replayMode {
+        case .actualDive:
+            generateFromActualSamples()
+        case .whatIfPlanning:
+            generateSyntheticProfile()
+        }
+    }
+
+    private func generateFromActualSamples() {
+        guard !samples.isEmpty else {
+            errorMessage = "No recorded samples available for this dive."
+            isGenerating = false
+            return
+        }
+
+        let params = buildDecoSimParams()
+
+        Task {
+            do {
+                let decoResult = try await Task.detached {
+                    try DivelogCompute.computeDecoSimulation(params: params)
+                }.value
+                result = .actual(decoResult)
+                isGenerating = false
+            } catch {
+                errorMessage = error.localizedDescription
+                isGenerating = false
+            }
+        }
+    }
+
+    private func generateSyntheticProfile() {
         let params: ProfileGenParams
         do {
             params = try buildParams()
@@ -690,13 +785,83 @@ struct ReplayProfileSheet: View {
                 let genResult = try await Task.detached {
                     try DivelogCompute.generateDiveProfile(params: params)
                 }.value
-                result = genResult
+                result = .synthetic(genResult)
                 isGenerating = false
             } catch {
                 errorMessage = error.localizedDescription
                 isGenerating = false
             }
         }
+    }
+
+    private func buildDecoSimParams() -> DecoSimParams {
+        let du = appState.depthUnit
+        let sorted = samples.sorted(by: { $0.tSec < $1.tSec })
+
+        // Truncate samples at the bottom-end point so the engine plans the ascent
+        // from peak tissue loading (not from the surface after the dive is over).
+        let maxDepth = sorted.map(\.depthM).max() ?? 0
+        let bottomEndIdx = sorted.lastIndex(where: { $0.depthM >= maxDepth * 0.95 }) ?? (sorted.count - 1)
+        let bottomSamples = Array(sorted[...bottomEndIdx])
+
+        var sampleInputs = bottomSamples.toSampleInputs()
+
+        // Only override PPO2 if the user changed the setpoint from the prefilled value.
+        // Otherwise, use the actual recorded per-sample PPO2 values from the dive computer.
+        if dive.isCcr, setpointText != originalSetpointText, let spOverride = Float(setpointText) {
+            for i in sampleInputs.indices {
+                sampleInputs[i] = SampleInput(
+                    tSec: sampleInputs[i].tSec,
+                    depthM: sampleInputs[i].depthM,
+                    tempC: sampleInputs[i].tempC,
+                    setpointPpo2: sampleInputs[i].setpointPpo2,
+                    ceilingM: sampleInputs[i].ceilingM,
+                    gf99: sampleInputs[i].gf99,
+                    gasmixIndex: sampleInputs[i].gasmixIndex,
+                    ppo2: spOverride,
+                    ttsSec: sampleInputs[i].ttsSec,
+                    ndlSec: sampleInputs[i].ndlSec,
+                    decoStopDepthM: sampleInputs[i].decoStopDepthM,
+                    atPlusFiveTtsMin: sampleInputs[i].atPlusFiveTtsMin
+                )
+            }
+        }
+
+        // Gas mixes: for CCR, apply diluent override; for OC, use dive's recorded gases
+        let gasMixInputs: [GasMixInput]
+        if dive.isCcr {
+            let o2 = Double(diluentO2Percent) / 100.0
+            let he = Double(diluentHePercent) / 100.0
+            gasMixInputs = [GasMixInput(mixIndex: 0, o2Fraction: o2, heFraction: he)]
+        } else {
+            gasMixInputs = gasMixes.toGasMixInputs()
+        }
+
+        // Compute ascent rate from the actual dive's transit phase
+        let ascentRate: Double
+        if let s = stats {
+            ascentRate = Double(computeTransitAscentRate(stats: s))
+        } else {
+            ascentRate = 9.0
+        }
+
+        let surfacePressure = Double(surfacePressureText)
+        let lastStop: Double? = Float(lastStopDepthText).map { Double(UnitFormatter.depthToMetric($0, from: du)) }
+        let stopInterval: Double? = Float(stopIntervalText).map { Double(UnitFormatter.depthToMetric($0, from: du)) }
+
+        return DecoSimParams(
+            model: selectedModel,
+            samples: sampleInputs,
+            gasMixes: gasMixInputs,
+            surfacePressureBar: surfacePressure,
+            ascentRateMMin: ascentRate,
+            lastStopDepthM: lastStop,
+            stopIntervalM: stopInterval,
+            gfLow: selectedModel == .buhlmannZhl16c ? UInt8(min(max(gfLow, 1), 100)) : nil,
+            gfHigh: selectedModel == .buhlmannZhl16c ? UInt8(min(max(gfHigh, 1), 100)) : nil,
+            thalmannPdcs: selectedModel == .thalmannElDca ? thalmannPdcs : nil,
+            planAscent: true
+        )
     }
 }
 

--- a/Profundum/Profundum/Views/ReplayProfileSheet.swift
+++ b/Profundum/Profundum/Views/ReplayProfileSheet.swift
@@ -36,6 +36,8 @@ struct ReplayProfileSheet: View {
     @State private var diluentHePercent: Int = 35
     @State private var setpointText: String = "1.3"
     @State private var originalSetpointText: String = ""
+    @State private var originalDiluentO2: Int = 21
+    @State private var originalDiluentHe: Int = 35
     @FocusState private var focusedField: Bool
     @State private var surfacePressureText: String = "1.01325"
     @State private var tempText: String = ""
@@ -451,10 +453,12 @@ struct ReplayProfileSheet: View {
 
     private func resultSummary(_ result: ReplayResult) -> some View {
         let extracted = extractResultData(result)
+        let isActual = if case .actual = result { true } else { false }
         return resultGrid(
             decoResult: extracted.decoResult,
             totalTimeSec: extracted.totalTimeSec,
-            decoTimeSec: extracted.decoTimeSec
+            decoTimeSec: extracted.decoTimeSec,
+            isActualDive: isActual
         )
     }
 
@@ -473,7 +477,8 @@ struct ReplayProfileSheet: View {
         }
     }
 
-    private func resultGrid(decoResult: DecoSimResult, totalTimeSec: Int32, decoTimeSec: Int32) -> some View {
+    // swiftlint:disable:next line_length
+    private func resultGrid(decoResult: DecoSimResult, totalTimeSec: Int32, decoTimeSec: Int32, isActualDive: Bool = false) -> some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Result")
                 .font(.headline)
@@ -494,11 +499,11 @@ struct ReplayProfileSheet: View {
             let columns = [GridItem(.flexible()), GridItem(.flexible())]
             LazyVGrid(columns: columns, spacing: 12) {
                 StatCard(
-                    title: "Total Time",
+                    title: isActualDive ? "Recorded Time" : "Total Time",
                     value: "\(totalTimeSec / 60) min"
                 )
                 StatCard(
-                    title: "Deco Stops",
+                    title: "Deco Stop Time",
                     value: "\(decoTimeSec / 60) min"
                 )
                 StatCard(
@@ -620,6 +625,8 @@ struct ReplayProfileSheet: View {
                 diluentO2Percent = max(5, min(100, Int(first.o2Fraction * 100)))
                 diluentHePercent = max(0, min(95, Int(first.heFraction * 100)))
             }
+            originalDiluentO2 = diluentO2Percent
+            originalDiluentHe = diluentHePercent
             // gasPlanEntries not used for CCR
             gasPlanEntries = []
         } else {
@@ -814,9 +821,21 @@ struct ReplayProfileSheet: View {
 
         var sampleInputs = bottomSamples.toSampleInputs()
 
-        // Only override PPO2 if the user changed the setpoint from the prefilled value.
-        // Otherwise, use the actual recorded per-sample PPO2 values from the dive computer.
-        if dive.isCcr, setpointText != originalSetpointText, let spOverride = Float(setpointText) {
+        // CCR setpoint override: only if user changed it from the prefilled value.
+        // Validate that the override is a valid number.
+        if dive.isCcr, setpointText != originalSetpointText {
+            guard let spOverride = Float(setpointText), spOverride > 0 else {
+                // Will be caught by generateFromActualSamples error handling
+                errorMessage = "Setpoint must be a valid positive number"
+                isGenerating = false
+                return DecoSimParams(
+                    model: selectedModel, samples: [], gasMixes: [],
+                    surfacePressureBar: nil, ascentRateMMin: nil,
+                    lastStopDepthM: nil, stopIntervalM: nil,
+                    gfLow: nil, gfHigh: nil, thalmannPdcs: nil,
+                    planAscent: false
+                )
+            }
             for i in sampleInputs.indices {
                 sampleInputs[i] = SampleInput(
                     tSec: sampleInputs[i].tSec,
@@ -835,9 +854,12 @@ struct ReplayProfileSheet: View {
             }
         }
 
-        // Gas mixes: for CCR, apply diluent override; for OC, use dive's recorded gases
+        // Gas mixes: use the dive's recorded gas table by default.
+        // Only override for CCR if the user changed diluent from prefilled values.
         let gasMixInputs: [GasMixInput]
-        if dive.isCcr {
+        let diluentChanged = dive.isCcr
+            && (diluentO2Percent != originalDiluentO2 || diluentHePercent != originalDiluentHe)
+        if diluentChanged {
             let o2 = Double(diluentO2Percent) / 100.0
             let he = Double(diluentHePercent) / 100.0
             gasMixInputs = [GasMixInput(mixIndex: 0, o2Fraction: o2, heFraction: he)]

--- a/Profundum/Profundum/Views/ReplayProfileSheet.swift
+++ b/Profundum/Profundum/Views/ReplayProfileSheet.swift
@@ -800,8 +800,16 @@ struct ReplayProfileSheet: View {
 
         // Truncate samples at the bottom-end point so the engine plans the ascent
         // from peak tissue loading (not from the surface after the dive is over).
-        let maxDepth = sorted.map(\.depthM).max() ?? 0
-        let bottomEndIdx = sorted.lastIndex(where: { $0.depthM >= maxDepth * 0.95 }) ?? (sorted.count - 1)
+        // Use DiveStats.bottomEndT when available (handles multi-level dives correctly),
+        // otherwise fall back to 95% of max depth.
+        let bottomEndT: Int32
+        if let s = stats, s.bottomEndT > 0 {
+            bottomEndT = s.bottomEndT
+        } else {
+            let maxDepth = sorted.map(\.depthM).max() ?? 0
+            bottomEndT = sorted.last(where: { $0.depthM >= maxDepth * 0.95 })?.tSec ?? sorted.last?.tSec ?? 0
+        }
+        let bottomEndIdx = sorted.lastIndex(where: { $0.tSec <= bottomEndT }) ?? (sorted.count - 1)
         let bottomSamples = Array(sorted[...bottomEndIdx])
 
         var sampleInputs = bottomSamples.toSampleInputs()

--- a/apple/DivelogCore/Sources/Models/DiveSample.swift
+++ b/apple/DivelogCore/Sources/Models/DiveSample.swift
@@ -116,6 +116,30 @@ extension DiveSample {
     static let dive = belongsTo(Dive.self)
 }
 
+// MARK: - Rust Bridge Mapping
+
+extension Array where Element == DiveSample {
+    /// Convert dive samples to Rust SampleInput array for deco engine computation.
+    public func toSampleInputs() -> [SampleInput] {
+        map { sample in
+            SampleInput(
+                tSec: sample.tSec,
+                depthM: sample.depthM,
+                tempC: sample.tempC,
+                setpointPpo2: sample.setpointPpo2,
+                ceilingM: sample.ceilingM,
+                gf99: sample.gf99,
+                gasmixIndex: sample.gasmixIndex.map { Int32($0) },
+                ppo2: sample.ppo2_1 ?? sample.setpointPpo2,
+                ttsSec: sample.ttsSec.map { Int32($0) },
+                ndlSec: sample.ndlSec.map { Int32($0) },
+                decoStopDepthM: sample.decoStopDepthM,
+                atPlusFiveTtsMin: sample.atPlusFiveTtsMin.map { Int32($0) }
+            )
+        }
+    }
+}
+
 // MARK: - Cache Key
 
 extension Array where Element == DiveSample {

--- a/apple/DivelogCore/Sources/Models/GasMix.swift
+++ b/apple/DivelogCore/Sources/Models/GasMix.swift
@@ -30,6 +30,21 @@ public struct GasMix: Identifiable, Equatable, Sendable {
     }
 }
 
+// MARK: - Rust Bridge Mapping
+
+extension Array where Element == GasMix {
+    /// Convert gas mixes to Rust GasMixInput array for deco engine computation.
+    public func toGasMixInputs() -> [GasMixInput] {
+        map { mix in
+            GasMixInput(
+                mixIndex: Int32(mix.mixIndex),
+                o2Fraction: Double(mix.o2Fraction),
+                heFraction: Double(mix.heFraction)
+            )
+        }
+    }
+}
+
 // MARK: - GRDB Conformance
 
 extension GasMix: Codable, FetchableRecord, PersistableRecord {

--- a/apple/DivelogCore/Sources/Services/FormulaService.swift
+++ b/apple/DivelogCore/Sources/Services/FormulaService.swift
@@ -137,22 +137,7 @@ public final class FormulaService: Sendable {
     // MARK: - Private Helpers
 
     private func makeSampleInputs(from samples: [DiveSample]) -> [SampleInput] {
-        samples.map { sample in
-            SampleInput(
-                tSec: sample.tSec,
-                depthM: sample.depthM,
-                tempC: sample.tempC,
-                setpointPpo2: sample.setpointPpo2,
-                ceilingM: sample.ceilingM,
-                gf99: sample.gf99,
-                gasmixIndex: sample.gasmixIndex.map { Int32($0) },
-                ppo2: sample.ppo2_1 ?? sample.setpointPpo2,
-                ttsSec: sample.ttsSec.map { Int32($0) },
-                ndlSec: sample.ndlSec.map { Int32($0) },
-                decoStopDepthM: sample.decoStopDepthM,
-                atPlusFiveTtsMin: sample.atPlusFiveTtsMin.map { Int32($0) }
-            )
-        }
+        samples.toSampleInputs()
     }
 
     private func computeDiveStats(dive: Dive, samples: [DiveSample]) -> DiveStats {

--- a/apple/DivelogCore/Tests/RustBridgeMappingTests.swift
+++ b/apple/DivelogCore/Tests/RustBridgeMappingTests.swift
@@ -1,0 +1,143 @@
+import XCTest
+@testable import DivelogCore
+
+final class RustBridgeMappingTests: XCTestCase {
+
+    // MARK: - DiveSample.toSampleInputs()
+
+    func testToSampleInputsEmpty() {
+        let samples: [DiveSample] = []
+        let result = samples.toSampleInputs()
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testToSampleInputsBasicMapping() {
+        let samples = [
+            DiveSample(
+                diveId: "d1",
+                tSec: 100,
+                depthM: 30.5,
+                tempC: 18.0,
+                setpointPpo2: 1.2,
+                ceilingM: 3.0,
+                gf99: 85.0,
+                ppo2_1: 1.15,
+                ttsSec: 600,
+                ndlSec: nil,
+                decoStopDepthM: 6.0,
+                gasmixIndex: 2,
+                atPlusFiveTtsMin: 12
+            ),
+        ]
+        let result = samples.toSampleInputs()
+        XCTAssertEqual(result.count, 1)
+        let s = result[0]
+        XCTAssertEqual(s.tSec, 100)
+        XCTAssertEqual(s.depthM, 30.5)
+        XCTAssertEqual(s.tempC, 18.0)
+        XCTAssertEqual(s.setpointPpo2, 1.2)
+        XCTAssertEqual(s.ceilingM, 3.0)
+        XCTAssertEqual(s.gf99, 85.0)
+        XCTAssertEqual(s.gasmixIndex, 2)
+        // ppo2 should prefer ppo2_1 over setpointPpo2
+        XCTAssertEqual(s.ppo2, 1.15)
+        XCTAssertEqual(s.ttsSec, 600)
+        XCTAssertNil(s.ndlSec)
+        XCTAssertEqual(s.decoStopDepthM, 6.0)
+        XCTAssertEqual(s.atPlusFiveTtsMin, 12)
+    }
+
+    func testToSampleInputsPpo2FallsBackToSetpoint() {
+        // When ppo2_1 is nil, ppo2 should fall back to setpointPpo2
+        let samples = [
+            DiveSample(
+                diveId: "d1",
+                tSec: 0,
+                depthM: 10.0,
+                tempC: 20.0,
+                setpointPpo2: 1.3,
+                ppo2_1: nil
+            ),
+        ]
+        let result = samples.toSampleInputs()
+        XCTAssertEqual(result[0].ppo2, 1.3)
+    }
+
+    func testToSampleInputsPpo2NilWhenBothNil() {
+        // When both ppo2_1 and setpointPpo2 are nil, ppo2 should be nil (OC dive)
+        let samples = [
+            DiveSample(
+                diveId: "d1",
+                tSec: 0,
+                depthM: 10.0,
+                tempC: 20.0
+            ),
+        ]
+        let result = samples.toSampleInputs()
+        XCTAssertNil(result[0].ppo2)
+    }
+
+    func testToSampleInputsMultipleSamples() {
+        let samples = [
+            DiveSample(diveId: "d1", tSec: 0, depthM: 0.0, tempC: 20.0),
+            DiveSample(diveId: "d1", tSec: 120, depthM: 30.0, tempC: 18.0),
+            DiveSample(diveId: "d1", tSec: 1200, depthM: 30.0, tempC: 17.5),
+            DiveSample(diveId: "d1", tSec: 1800, depthM: 0.0, tempC: 20.0),
+        ]
+        let result = samples.toSampleInputs()
+        XCTAssertEqual(result.count, 4)
+        XCTAssertEqual(result[0].tSec, 0)
+        XCTAssertEqual(result[1].depthM, 30.0)
+        XCTAssertEqual(result[2].tSec, 1200)
+        XCTAssertEqual(result[3].depthM, 0.0)
+    }
+
+    func testToSampleInputsGasmixIndexConversion() {
+        // gasmixIndex is Int in DiveSample, Int32 in SampleInput
+        let samples = [
+            DiveSample(diveId: "d1", tSec: 0, depthM: 10.0, tempC: 20.0, gasmixIndex: 0),
+            DiveSample(diveId: "d1", tSec: 60, depthM: 10.0, tempC: 20.0, gasmixIndex: 1),
+            DiveSample(diveId: "d1", tSec: 120, depthM: 10.0, tempC: 20.0), // nil gasmixIndex
+        ]
+        let result = samples.toSampleInputs()
+        XCTAssertEqual(result[0].gasmixIndex, 0)
+        XCTAssertEqual(result[1].gasmixIndex, 1)
+        XCTAssertNil(result[2].gasmixIndex)
+    }
+
+    // MARK: - GasMix.toGasMixInputs()
+
+    func testToGasMixInputsEmpty() {
+        let mixes: [GasMix] = []
+        let result = mixes.toGasMixInputs()
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testToGasMixInputsBasicMapping() {
+        let mixes = [
+            GasMix(diveId: "d1", mixIndex: 0, o2Fraction: 0.21, heFraction: 0.35),
+            GasMix(diveId: "d1", mixIndex: 1, o2Fraction: 0.50, heFraction: 0.0),
+        ]
+        let result = mixes.toGasMixInputs()
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0].mixIndex, 0)
+        XCTAssertEqual(result[0].o2Fraction, 0.21, accuracy: 0.001)
+        XCTAssertEqual(result[0].heFraction, 0.35, accuracy: 0.001)
+        XCTAssertEqual(result[1].mixIndex, 1)
+        XCTAssertEqual(result[1].o2Fraction, 0.50, accuracy: 0.001)
+        XCTAssertEqual(result[1].heFraction, 0.0, accuracy: 0.001)
+    }
+
+    func testToGasMixInputsTypeConversion() {
+        // mixIndex is Int in GasMix, Int32 in GasMixInput
+        // o2/he are Float in GasMix, Double in GasMixInput
+        let mixes = [
+            GasMix(diveId: "d1", mixIndex: 3, o2Fraction: 0.18, heFraction: 0.45),
+        ]
+        let result = mixes.toGasMixInputs()
+        XCTAssertEqual(result[0].mixIndex, 3)
+        // Float → Double precision should be close
+        XCTAssertEqual(result[0].o2Fraction, Double(Float(0.18)), accuracy: 1e-6)
+        XCTAssertEqual(result[0].heFraction, Double(Float(0.45)), accuracy: 1e-6)
+    }
+}


### PR DESCRIPTION
## Summary

- **New "Actual Dive" replay mode** (default): feeds recorded dive samples through the deco engine with `planAscent: true`, computing the deco schedule the algorithm would prescribe for the actual dive profile
- **Samples truncated at bottom-end**: engine plans ascent from peak tissue loading, not from surface after dive is over
- **Ascent rate from actual dive**: uses computed transit-phase ascent rate instead of hardcoded 9 m/min
- **CCR setpoint override**: uses recorded per-sample PPO2 by default; only overrides when user explicitly changes the setpoint field
- **"What-If Planning" mode**: existing synthetic profile generator preserved as secondary mode
- **Shared mapping extensions**: `[DiveSample].toSampleInputs()` and `[GasMix].toGasMixInputs()` extracted to DivelogCore, deduplicating FormulaService and DepthProfileChart

### Validated on device
- CCR 200ft/29min dive with GF 50/90: engine computes 31 min deco stops vs 34 min actual (3 min difference from imperfect stop execution — expected)

## Test plan

- [x] `make lint` — clean
- [x] `make test` — all pass
- [x] macOS build — clean
- [x] `make security` — clean
- [x] `make version-check` — consistent
- [x] On-device testing (iPhone) — actual-dive mode produces reasonable results
- [ ] `/review-pr` — pending
- [ ] Codex MCP review — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)