### PR TITLE
Add replay chart v2 with ceiling/GF overlays and fullscreen (PRO-51)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,10 @@ apple/DivelogCore/Sources/RustBridge/Generated/
 lcov.info
 coverage/
 
+# cargo-mutants output
+core/mutants.out/
+core/mutants.out.old/
+
 # Temporary files
 *.tmp
 *.temp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,7 +223,7 @@ Variables available for segment formulas:
 | Step | Action | Notes |
 |------|--------|-------|
 | 7. Self-review | Run `/review-pr` skill | Structured review against project checklist |
-| 8. Second-opinion review | Send diff to Codex MCP | Independent review for bugs, edge cases, improvements |
+| 8. Second-opinion review | Launch a review subagent with a non-primary model (e.g. `gpt-5.3-codex` when working in Claude, or vice versa) | Independent review for bugs, edge cases, improvements. No external MCP required — Cursor's multi-model subagents provide the independent perspective natively. |
 
 All 8 steps are mandatory. Do not skip any step.
 

--- a/Profundum/Profundum.xcodeproj/project.pbxproj
+++ b/Profundum/Profundum.xcodeproj/project.pbxproj
@@ -424,7 +424,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.2;
 				MARKETING_VERSION = 0.1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = azlucis.Profundum;
+				PRODUCT_BUNDLE_IDENTIFIER = com.azlucis.Profundum;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
@@ -470,7 +470,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.2;
 				MARKETING_VERSION = 0.1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = azlucis.Profundum;
+				PRODUCT_BUNDLE_IDENTIFIER = com.azlucis.Profundum;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;

--- a/Profundum/Profundum.xcodeproj/project.pbxproj
+++ b/Profundum/Profundum.xcodeproj/project.pbxproj
@@ -424,7 +424,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.2;
 				MARKETING_VERSION = 0.1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.azlucis.Profundum;
+				PRODUCT_BUNDLE_IDENTIFIER = azlucis.Profundum;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
@@ -470,7 +470,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.2;
 				MARKETING_VERSION = 0.1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.azlucis.Profundum;
+				PRODUCT_BUNDLE_IDENTIFIER = azlucis.Profundum;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;

--- a/Profundum/Profundum/Views/ReplayChart.swift
+++ b/Profundum/Profundum/Views/ReplayChart.swift
@@ -1,0 +1,1064 @@
+import Charts
+import DivelogCore
+import SwiftUI
+
+// MARK: - Deco stop band
+
+struct DecoStopBand: Identifiable {
+    let id: Int
+    let startTimeMinutes: Float
+    let endTimeMinutes: Float
+    /// Positive depth in display units.
+    let depth: Float
+    let gasLabel: String?
+    let durationLabel: String
+}
+
+// MARK: - Precomputed replay chart data
+
+struct ReplayChartData {
+    let depthPoints: [DepthDataPoint]
+    let maxDepth: Float
+    let totalMinutes: Float
+
+    let hasCeilingData: Bool
+    let ceilingPoints: [CeilingDataPoint]
+
+    let hasGf99Data: Bool
+    let gf99DisplayRange: (min: Float, max: Float)?
+    let gf99Points: [OverlayDataPoint]
+
+    let hasSurfGfData: Bool
+    let surfGfDisplayRange: (min: Float, max: Float)?
+    let surfGfPoints: [OverlayDataPoint]
+
+    let gasSwitchMarkers: [GasSwitchMarker]
+    let decoStopBands: [DecoStopBand]
+
+    let descentEndTimeMinutes: Float
+    let bottomEndTimeMinutes: Float
+
+    /// Lookup: sample tSec -> depth in display units (for scrub readout).
+    let depthLookup: [Int32: Float]
+    /// Lookup: sample tSec -> ceiling in metres (for scrub readout).
+    let ceilingLookup: [Int32: Float]
+    /// Lookup: sample tSec -> GF99 percentage (for scrub readout).
+    let gf99Lookup: [Int32: Float]
+    /// Lookup: sample tSec -> SurfGF percentage (for scrub readout).
+    let surfGfLookup: [Int32: Float]
+    /// Lookup: sample tSec -> TTS in seconds (for scrub readout).
+    let ttsLookup: [Int32: Int32]
+    /// Lookup: sample tSec -> NDL in seconds (for scrub readout).
+    let ndlLookup: [Int32: Int32]
+    /// Lookup: sample tSec -> gas label (for scrub readout).
+    let gasLookup: [Int32: String]
+
+    var domainMin: Float { -(maxDepth * 1.15) }
+    var domainMax: Float { maxDepth * 0.05 }
+
+    // MARK: - Synthetic profile initializer
+
+    // swiftlint:disable:next function_body_length
+    init(result: ProfileGenResult, depthUnit: DepthUnit) {
+        let samples = result.samples
+        let decoPoints = result.decoResult.points
+        let gasMixes = result.gasMixes
+
+        // -- Depth points --
+        var maxD: Float = 0
+        for s in samples {
+            let d = UnitFormatter.depth(s.depthM, unit: depthUnit)
+            if d > maxD { maxD = d }
+        }
+        if maxD < 1 { maxD = 30 }
+        self.maxDepth = maxD
+
+        let depthStride = max(1, samples.count / 300)
+        var depths: [DepthDataPoint] = []
+        depths.reserveCapacity(302)
+        var di = 0
+        var depthIdx = 0
+        while di < samples.count {
+            let t = Float(samples[di].tSec) / 60.0
+            let d = UnitFormatter.depth(samples[di].depthM, unit: depthUnit)
+            depths.append(DepthDataPoint(id: depthIdx, timeMinutes: t, depth: d))
+            depthIdx += 1
+            di += depthStride
+        }
+        if let last = samples.last {
+            let lastT = Float(last.tSec) / 60.0
+            if depths.last?.timeMinutes != lastT {
+                let d = UnitFormatter.depth(last.depthM, unit: depthUnit)
+                depths.append(DepthDataPoint(id: depthIdx, timeMinutes: lastT, depth: d))
+            }
+        }
+        self.depthPoints = depths
+        self.totalMinutes = depths.last?.timeMinutes ?? 0
+
+        // -- Depth lookup (full resolution, for scrub readout) --
+        var dLookup: [Int32: Float] = [:]
+        for s in samples {
+            dLookup[s.tSec] = UnitFormatter.depth(s.depthM, unit: depthUnit)
+        }
+        self.depthLookup = dLookup
+
+        // -- Ceiling points from DecoSimResult.points --
+        var ceilings: [CeilingDataPoint] = []
+        var hasCeiling = false
+        let ceilingStride = max(1, decoPoints.count / 300)
+        var ci = 0
+        var cIdx = 0
+        while ci < decoPoints.count {
+            let pt = decoPoints[ci]
+            if pt.ceilingM > 0 {
+                hasCeiling = true
+                let t = Float(pt.tSec) / 60.0
+                let cDepth = UnitFormatter.depth(pt.ceilingM, unit: depthUnit)
+                ceilings.append(CeilingDataPoint(id: cIdx, timeMinutes: t, ceilingDepth: cDepth))
+                cIdx += 1
+            }
+            ci += ceilingStride
+        }
+        self.hasCeilingData = hasCeiling
+        self.ceilingPoints = ceilings
+
+        // -- Ceiling, TTS, NDL lookups --
+        var cLookup: [Int32: Float] = [:]
+        var ttsLook: [Int32: Int32] = [:]
+        var ndlLook: [Int32: Int32] = [:]
+        for pt in decoPoints {
+            if pt.ceilingM > 0 { cLookup[pt.tSec] = pt.ceilingM }
+            if pt.ttsSec > 0 { ttsLook[pt.tSec] = pt.ttsSec }
+            if pt.ndlSec > 0 { ndlLook[pt.tSec] = pt.ndlSec }
+        }
+        self.ceilingLookup = cLookup
+        self.ttsLookup = ttsLook
+        self.ndlLookup = ndlLook
+
+        // -- GF99 overlay --
+        let (hasGf99, gf99Range, gf99Pts) = Self.downsampleOverlay(
+            decoPoints: decoPoints, maxDepth: maxD, extract: { $0.gf99 > 0 ? $0.gf99 : nil }
+        )
+        self.hasGf99Data = hasGf99
+        self.gf99DisplayRange = gf99Range
+        self.gf99Points = gf99Pts
+
+        var g99Lookup: [Int32: Float] = [:]
+        for pt in decoPoints where pt.gf99 > 0 {
+            g99Lookup[pt.tSec] = pt.gf99
+        }
+        self.gf99Lookup = g99Lookup
+
+        // -- SurfGF overlay --
+        let (hasSurfGf, surfGfRange, surfGfPts) = Self.downsampleOverlay(
+            decoPoints: decoPoints, maxDepth: maxD, extract: { $0.surfaceGf > 0 ? $0.surfaceGf : nil }
+        )
+        self.hasSurfGfData = hasSurfGf
+        self.surfGfDisplayRange = surfGfRange
+        self.surfGfPoints = surfGfPts
+
+        var sgLookup: [Int32: Float] = [:]
+        for pt in decoPoints where pt.surfaceGf > 0 {
+            sgLookup[pt.tSec] = pt.surfaceGf
+        }
+        self.surfGfLookup = sgLookup
+
+        // -- Gas switch markers --
+        // Build mixIndex -> label dictionary for O(1) lookup
+        var mixLabels: [Int32: String] = [:]
+        for mix in gasMixes {
+            mixLabels[mix.mixIndex] = DepthProfileChartData.gasLabel(
+                o2: Float(mix.o2Fraction), he: Float(mix.heFraction)
+            )
+        }
+
+        var markers: [GasSwitchMarker] = []
+        var gasLook: [Int32: String] = [:]
+        var currentMixIdx: Int32 = gasMixes.first?.mixIndex ?? -1
+        var currentLabel = mixLabels[currentMixIdx]
+
+        for s in samples {
+            let mixIdx = s.gasmixIndex ?? currentMixIdx
+            if mixIdx != currentMixIdx, mixIdx >= 0, let label = mixLabels[mixIdx] {
+                currentMixIdx = mixIdx
+                currentLabel = label
+                markers.append(GasSwitchMarker(
+                    id: markers.count,
+                    timeMinutes: Float(s.tSec) / 60.0,
+                    gasLabel: label,
+                    color: DepthProfileChartData.gasColor(index: markers.count)
+                ))
+            }
+            if let label = currentLabel {
+                gasLook[s.tSec] = label
+            }
+        }
+        self.gasSwitchMarkers = markers
+        self.gasLookup = gasLook
+
+        // -- Deco stop bands from pass-1 planned stops --
+        // Match each planned stop to its time range in the sample profile.
+        var bands: [DecoStopBand] = []
+        let plannedStops = result.plannedStops
+        if !plannedStops.isEmpty {
+            let bottomEnd = result.bottomEndTSec
+            var stopQueue = plannedStops[...]
+            var bandStart: Int32?
+            var bandDepthM: Float = 0
+
+            for s in samples where s.tSec >= bottomEnd {
+                guard let nextStop = stopQueue.first else { break }
+                if abs(s.depthM - nextStop.depthM) < 0.5 {
+                    if bandStart == nil {
+                        bandStart = s.tSec
+                        bandDepthM = nextStop.depthM
+                    }
+                } else if let start = bandStart {
+                    let durSec = s.tSec - start
+                    let gasLabel = mixLabels[nextStop.gasMixIndex]
+                    let durLabel = durSec >= 60
+                        ? "\(durSec / 60) min"
+                        : "\(durSec) sec"
+                    bands.append(DecoStopBand(
+                        id: bands.count,
+                        startTimeMinutes: Float(start) / 60.0,
+                        endTimeMinutes: Float(s.tSec) / 60.0,
+                        depth: UnitFormatter.depth(bandDepthM, unit: depthUnit),
+                        gasLabel: gasLabel,
+                        durationLabel: durLabel
+                    ))
+                    bandStart = nil
+                    stopQueue = stopQueue.dropFirst()
+                }
+            }
+            // Close any open band at end of dive
+            if let start = bandStart, let nextStop = stopQueue.first, let lastSample = samples.last {
+                let durSec = lastSample.tSec - start
+                let gasLabel = mixLabels[nextStop.gasMixIndex]
+                let durLabel = durSec >= 60
+                    ? "\(durSec / 60) min"
+                    : "\(durSec) sec"
+                bands.append(DecoStopBand(
+                    id: bands.count,
+                    startTimeMinutes: Float(start) / 60.0,
+                    endTimeMinutes: Float(lastSample.tSec) / 60.0,
+                    depth: UnitFormatter.depth(bandDepthM, unit: depthUnit),
+                    gasLabel: gasLabel,
+                    durationLabel: durLabel
+                ))
+            }
+        }
+        self.decoStopBands = bands
+
+        // -- Phase markers --
+        self.descentEndTimeMinutes = Float(result.descentEndTSec) / 60.0
+        self.bottomEndTimeMinutes = Float(result.bottomEndTSec) / 60.0
+    }
+
+    // MARK: - Actual dive initializer
+
+    // swiftlint:disable:next function_body_length
+    init(samples: [DiveSample], decoResult: DecoSimResult, gasMixes: [GasMix], depthUnit: DepthUnit) {
+        let decoPoints = decoResult.points
+
+        // -- Depth points from DiveSample --
+        var maxD: Float = 0
+        for s in samples {
+            let d = UnitFormatter.depth(s.depthM, unit: depthUnit)
+            if d > maxD { maxD = d }
+        }
+        if maxD < 1 { maxD = 30 }
+        self.maxDepth = maxD
+
+        let depthStride = max(1, samples.count / 300)
+        var depths: [DepthDataPoint] = []
+        depths.reserveCapacity(302)
+        var di = 0
+        var depthIdx = 0
+        while di < samples.count {
+            let t = Float(samples[di].tSec) / 60.0
+            let d = UnitFormatter.depth(samples[di].depthM, unit: depthUnit)
+            depths.append(DepthDataPoint(id: depthIdx, timeMinutes: t, depth: d))
+            depthIdx += 1
+            di += depthStride
+        }
+        if let last = samples.last {
+            let lastT = Float(last.tSec) / 60.0
+            if depths.last?.timeMinutes != lastT {
+                let d = UnitFormatter.depth(last.depthM, unit: depthUnit)
+                depths.append(DepthDataPoint(id: depthIdx, timeMinutes: lastT, depth: d))
+            }
+        }
+        self.depthPoints = depths
+        self.totalMinutes = depths.last?.timeMinutes ?? 0
+
+        // -- Depth lookup --
+        var dLookup: [Int32: Float] = [:]
+        for s in samples {
+            dLookup[s.tSec] = UnitFormatter.depth(s.depthM, unit: depthUnit)
+        }
+        self.depthLookup = dLookup
+
+        // -- Ceiling points from DecoSimResult.points --
+        var ceilings: [CeilingDataPoint] = []
+        var hasCeiling = false
+        let ceilingStride = max(1, decoPoints.count / 300)
+        var ci = 0
+        var cIdx = 0
+        while ci < decoPoints.count {
+            let pt = decoPoints[ci]
+            if pt.ceilingM > 0 {
+                hasCeiling = true
+                let t = Float(pt.tSec) / 60.0
+                let cDepth = UnitFormatter.depth(pt.ceilingM, unit: depthUnit)
+                ceilings.append(CeilingDataPoint(id: cIdx, timeMinutes: t, ceilingDepth: cDepth))
+                cIdx += 1
+            }
+            ci += ceilingStride
+        }
+        self.hasCeilingData = hasCeiling
+        self.ceilingPoints = ceilings
+
+        // -- Ceiling, TTS, NDL lookups --
+        var cLookup: [Int32: Float] = [:]
+        var ttsLook: [Int32: Int32] = [:]
+        var ndlLook: [Int32: Int32] = [:]
+        for pt in decoPoints {
+            if pt.ceilingM > 0 { cLookup[pt.tSec] = pt.ceilingM }
+            if pt.ttsSec > 0 { ttsLook[pt.tSec] = pt.ttsSec }
+            if pt.ndlSec > 0 { ndlLook[pt.tSec] = pt.ndlSec }
+        }
+        self.ceilingLookup = cLookup
+        self.ttsLookup = ttsLook
+        self.ndlLookup = ndlLook
+
+        // -- GF99 overlay --
+        let (hasGf99, gf99Range, gf99Pts) = Self.downsampleOverlay(
+            decoPoints: decoPoints, maxDepth: maxD, extract: { $0.gf99 > 0 ? $0.gf99 : nil }
+        )
+        self.hasGf99Data = hasGf99
+        self.gf99DisplayRange = gf99Range
+        self.gf99Points = gf99Pts
+
+        var g99Lookup: [Int32: Float] = [:]
+        for pt in decoPoints where pt.gf99 > 0 {
+            g99Lookup[pt.tSec] = pt.gf99
+        }
+        self.gf99Lookup = g99Lookup
+
+        // -- SurfGF overlay --
+        let (hasSurfGf, surfGfRange, surfGfPts) = Self.downsampleOverlay(
+            decoPoints: decoPoints, maxDepth: maxD, extract: { $0.surfaceGf > 0 ? $0.surfaceGf : nil }
+        )
+        self.hasSurfGfData = hasSurfGf
+        self.surfGfDisplayRange = surfGfRange
+        self.surfGfPoints = surfGfPts
+
+        var sgLookup: [Int32: Float] = [:]
+        for pt in decoPoints where pt.surfaceGf > 0 {
+            sgLookup[pt.tSec] = pt.surfaceGf
+        }
+        self.surfGfLookup = sgLookup
+
+        // -- Gas switch markers from gasmixIndex changes in samples --
+        var mixLabels: [Int: String] = [:]
+        for mix in gasMixes {
+            mixLabels[mix.mixIndex] = DepthProfileChartData.gasLabel(
+                o2: mix.o2Fraction, he: mix.heFraction
+            )
+        }
+
+        var markers: [GasSwitchMarker] = []
+        var gasLook: [Int32: String] = [:]
+        var currentMixIdx: Int = gasMixes.first?.mixIndex ?? -1
+        var currentLabel = mixLabels[currentMixIdx]
+
+        for s in samples {
+            let mixIdx = s.gasmixIndex ?? currentMixIdx
+            if mixIdx != currentMixIdx, mixIdx >= 0, let label = mixLabels[mixIdx] {
+                currentMixIdx = mixIdx
+                currentLabel = label
+                markers.append(GasSwitchMarker(
+                    id: markers.count,
+                    timeMinutes: Float(s.tSec) / 60.0,
+                    gasLabel: label,
+                    color: DepthProfileChartData.gasColor(index: markers.count)
+                ))
+            }
+            if let label = currentLabel {
+                gasLook[s.tSec] = label
+            }
+        }
+        self.gasSwitchMarkers = markers
+        self.gasLookup = gasLook
+
+        // No deco stop bands for actual dives (no planned stops)
+        self.decoStopBands = []
+
+        // No phase markers for actual dives
+        self.descentEndTimeMinutes = 0
+        self.bottomEndTimeMinutes = 0
+    }
+
+    /// Binary search for the nearest depth point to a given time.
+    func nearestDepthPoint(to time: Float) -> DepthDataPoint? {
+        guard !depthPoints.isEmpty else { return nil }
+        var lo = 0
+        var hi = depthPoints.count - 1
+        while lo < hi {
+            let mid = (lo + hi) / 2
+            if depthPoints[mid].timeMinutes < time {
+                lo = mid + 1
+            } else {
+                hi = mid
+            }
+        }
+        if lo > 0 {
+            let prev = depthPoints[lo - 1]
+            let curr = depthPoints[lo]
+            if abs(prev.timeMinutes - time) < abs(curr.timeMinutes - time) {
+                return prev
+            }
+        }
+        return depthPoints[lo]
+    }
+
+    /// Binary search for the nearest sample tSec to a given time in minutes.
+    func nearestTSec(to timeMinutes: Float, in samples: [SampleInput]) -> Int32? {
+        guard !samples.isEmpty else { return nil }
+        let targetSec = Int32((timeMinutes * 60.0).rounded())
+        var lo = 0
+        var hi = samples.count - 1
+        while lo < hi {
+            let mid = (lo + hi) / 2
+            if samples[mid].tSec < targetSec {
+                lo = mid + 1
+            } else {
+                hi = mid
+            }
+        }
+        if lo > 0 {
+            let prev = samples[lo - 1].tSec
+            let curr = samples[lo].tSec
+            if abs(prev - targetSec) < abs(curr - targetSec) {
+                return prev
+            }
+        }
+        return samples[lo].tSec
+    }
+
+    /// Denormalize a negative Y chart value back to GF99 percentage.
+    func denormalizeGf99(_ yValue: Float) -> Float {
+        guard let range = gf99DisplayRange else { return 0 }
+        let fraction = 1.0 + yValue / maxDepth
+        return range.min + fraction * (range.max - range.min)
+    }
+
+    /// Denormalize a negative Y chart value back to SurfGF percentage.
+    func denormalizeSurfGf(_ yValue: Float) -> Float {
+        guard let range = surfGfDisplayRange else { return 0 }
+        let fraction = 1.0 + yValue / maxDepth
+        return range.min + fraction * (range.max - range.min)
+    }
+
+    // MARK: - Overlay downsampling
+
+    private static func downsampleOverlay(
+        decoPoints: [DecoSimPoint],
+        maxDepth: Float,
+        extract: (DecoSimPoint) -> Float?
+    ) -> (hasData: Bool, range: (min: Float, max: Float)?, points: [OverlayDataPoint]) {
+        var minVal: Float = .greatestFiniteMagnitude
+        var maxVal: Float = -.greatestFiniteMagnitude
+        var anyData = false
+        for pt in decoPoints {
+            if let v = extract(pt) {
+                anyData = true
+                if v < minVal { minVal = v }
+                if v > maxVal { maxVal = v }
+            }
+        }
+        guard anyData else { return (false, nil, []) }
+
+        let span = maxVal - minVal
+        let pad = span > 0.1 ? span * 0.15 : max(abs(minVal) * 0.1, 1)
+        let range = (min: minVal - pad, max: maxVal + pad)
+        let rangeDelta = range.max - range.min
+
+        let targetCount = 300
+        let stride = max(1, decoPoints.count / targetCount)
+        var pts: [OverlayDataPoint] = []
+        pts.reserveCapacity(targetCount + 2)
+        var si = 0
+        var idx = 0
+        while si < decoPoints.count {
+            let pt = decoPoints[si]
+            let t = Float(pt.tSec) / 60.0
+            if let v = extract(pt) {
+                let fraction = (v - range.min) / rangeDelta
+                let normalized = -(maxDepth * (1.0 - fraction))
+                pts.append(OverlayDataPoint(id: idx, timeMinutes: t, normalizedValue: normalized))
+                idx += 1
+            }
+            si += stride
+        }
+        if let last = decoPoints.last, let v = extract(last) {
+            let lastT = Float(last.tSec) / 60.0
+            if pts.last?.timeMinutes != lastT {
+                let fraction = (v - range.min) / rangeDelta
+                let normalized = -(maxDepth * (1.0 - fraction))
+                pts.append(OverlayDataPoint(id: idx, timeMinutes: lastT, normalizedValue: normalized))
+            }
+        }
+        return (true, range, pts)
+    }
+}
+
+// MARK: - Animation speed
+
+enum AnimationSpeed: Float, CaseIterable, Identifiable {
+    case x5 = 5
+    case x10 = 10
+    case x30 = 30
+    case x60 = 60
+    case x120 = 120
+
+    var id: Float { rawValue }
+
+    var label: String {
+        switch self {
+        case .x5: "5x"
+        case .x10: "10x"
+        case .x30: "30x"
+        case .x60: "60x"
+        case .x120: "120x"
+        }
+    }
+
+    var slower: AnimationSpeed? {
+        guard let idx = Self.allCases.firstIndex(of: self), idx > 0 else { return nil }
+        return Self.allCases[idx - 1]
+    }
+
+    var faster: AnimationSpeed? {
+        guard let idx = Self.allCases.firstIndex(of: self), idx < Self.allCases.count - 1 else { return nil }
+        return Self.allCases[idx + 1]
+    }
+}
+
+// MARK: - Animation controller
+
+@MainActor @Observable
+final class ReplayAnimationController {
+    var visibleTimeSec: Float = 0
+    var isPlaying: Bool = false
+    var speed: AnimationSpeed = .x30
+    let totalTimeSec: Float
+
+    private var timer: Timer?
+
+    init(totalTimeSec: Float) {
+        self.totalTimeSec = totalTimeSec
+    }
+
+    var visibleTimeMinutes: Float { visibleTimeSec / 60.0 }
+    var progress: Float { totalTimeSec > 0 ? visibleTimeSec / totalTimeSec : 0 }
+    var isAtEnd: Bool { visibleTimeSec >= totalTimeSec }
+
+    var currentTimeLabel: String {
+        let cur = Int(visibleTimeSec)
+        let total = Int(totalTimeSec)
+        return "\(cur / 60):\(String(format: "%02d", cur % 60)) / \(total / 60):\(String(format: "%02d", total % 60))"
+    }
+
+    func play() {
+        guard totalTimeSec > 0 else { return }
+        guard !isAtEnd else {
+            reset()
+            return startPlaying()
+        }
+        startPlaying()
+    }
+
+    func pause() {
+        isPlaying = false
+        timer?.invalidate()
+        timer = nil
+    }
+
+    func reset() {
+        pause()
+        visibleTimeSec = 0
+    }
+
+    func scrub(to time: Float) {
+        pause()
+        visibleTimeSec = min(max(time, 0), totalTimeSec)
+    }
+
+    private func startPlaying() {
+        isPlaying = true
+        let interval: TimeInterval = 1.0 / 30.0
+        let t = Timer(timeInterval: interval, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.visibleTimeSec += self.speed.rawValue * Float(interval)
+                if self.visibleTimeSec >= self.totalTimeSec {
+                    self.visibleTimeSec = self.totalTimeSec
+                    self.pause()
+                    #if os(iOS)
+                    UIAccessibility.post(notification: .announcement, argument: "Profile animation complete")
+                    #endif
+                }
+            }
+        }
+        RunLoop.main.add(t, forMode: .common)
+        timer = t
+    }
+
+    deinit {
+        // Timer is already invalidated by pause() in onDisappear;
+        // MainActor isolation prevents direct access here.
+    }
+}
+
+// MARK: - Replay chart view
+
+struct ReplayChart: View {
+    let data: ReplayChartData
+    let visibleTimeMinutes: Float
+    let samples: [SampleInput]
+    var showCeiling: Bool = true
+    var showGf99: Bool = false
+    var showSurfGf: Bool = false
+    var isFullscreen: Bool = false
+    var depthUnit: DepthUnit = .meters
+
+    @State private var selectedTime: Float?
+
+    private var selectedPoint: DepthDataPoint? {
+        guard let selectedTime else { return nil }
+        return data.nearestDepthPoint(to: selectedTime)
+    }
+
+    var body: some View {
+        VStack(spacing: 2) {
+            readoutBar
+                .opacity(selectedTime != nil ? 1 : 0)
+            chartContent
+        }
+    }
+
+    // MARK: - Chart content
+
+    private var chartContent: some View {
+        Chart {
+            depthContent
+            if showCeiling { ceilingContent }
+            if showGf99 { gf99Content }
+            if showSurfGf { surfGfContent }
+            decoStopContent
+            gasSwitchContent
+            phaseMarkerContent
+            scrubContent
+        }
+        .chartYScale(domain: data.domainMin ... data.domainMax)
+        .chartXScale(domain: 0 ... data.totalMinutes)
+        .chartLegend(.hidden)
+        .chartXAxis {
+            AxisMarks(values: .automatic) { value in
+                AxisGridLine()
+                AxisValueLabel {
+                    if let minutes = value.as(Float.self) {
+                        Text("\(Int(minutes)) min")
+                    }
+                }
+            }
+        }
+        .chartYAxis {
+            AxisMarks(position: .leading, values: .automatic) { value in
+                AxisGridLine()
+                AxisValueLabel {
+                    if let depth = value.as(Float.self) {
+                        Text(String(format: "%.0f%@", abs(depth), UnitFormatter.depthLabel(depthUnit)))
+                    }
+                }
+            }
+            if showGf99 {
+                AxisMarks(position: .trailing, values: .automatic) { value in
+                    AxisValueLabel {
+                        if let yVal = value.as(Float.self) {
+                            let gf = data.denormalizeGf99(yVal)
+                            if gf >= 0 { Text(String(format: "%.0f%%", gf)) }
+                        }
+                    }
+                }
+            } else if showSurfGf {
+                AxisMarks(position: .trailing, values: .automatic) { value in
+                    AxisValueLabel {
+                        if let yVal = value.as(Float.self) {
+                            let sgf = data.denormalizeSurfGf(yVal)
+                            if sgf >= 0 { Text(String(format: "%.0f%%", sgf)) }
+                        }
+                    }
+                }
+            }
+        }
+        .chartOverlay { proxy in
+            GeometryReader { geometry in
+                Rectangle()
+                    .fill(Color.clear)
+                    .contentShape(Rectangle())
+                    .gesture(
+                        DragGesture(minimumDistance: 0)
+                            .onChanged { value in
+                                guard let plotFrame = proxy.plotFrame else { return }
+                                let origin = geometry[plotFrame].origin
+                                let x = value.location.x - origin.x
+                                if let time: Float = proxy.value(atX: x) {
+                                    selectedTime = max(0, min(time, visibleTimeMinutes))
+                                }
+                            }
+                            .onEnded { _ in
+                                selectedTime = nil
+                            }
+                    )
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(chartAccessibilityLabel)
+    }
+
+    // MARK: - Chart layers
+
+    @ChartContentBuilder
+    private var depthContent: some ChartContent {
+        ForEach(data.depthPoints.prefix(while: { $0.timeMinutes <= visibleTimeMinutes })) { point in
+            LineMark(
+                x: .value("Time", point.timeMinutes),
+                y: .value("Depth", -point.depth),
+                series: .value("Series", "Depth")
+            )
+            .foregroundStyle(Color.blue)
+            .lineStyle(StrokeStyle(lineWidth: 2))
+        }
+    }
+
+    @ChartContentBuilder
+    private var ceilingContent: some ChartContent {
+        if data.hasCeilingData {
+            ForEach(data.ceilingPoints.prefix(while: { $0.timeMinutes <= visibleTimeMinutes })) { point in
+                AreaMark(
+                    x: .value("Time", point.timeMinutes),
+                    yStart: .value("Surface", Float(0)),
+                    yEnd: .value("Ceiling", -point.ceilingDepth)
+                )
+                .foregroundStyle(Color.red.opacity(0.25))
+            }
+            ForEach(data.ceilingPoints.prefix(while: { $0.timeMinutes <= visibleTimeMinutes })) { point in
+                LineMark(
+                    x: .value("Time", point.timeMinutes),
+                    y: .value("Ceiling Line", -point.ceilingDepth),
+                    series: .value("Series", "Ceiling")
+                )
+                .foregroundStyle(Color.red.opacity(0.6))
+                .lineStyle(StrokeStyle(lineWidth: 1.5))
+            }
+        }
+    }
+
+    @ChartContentBuilder
+    private var gf99Content: some ChartContent {
+        ForEach(data.gf99Points.prefix(while: { $0.timeMinutes <= visibleTimeMinutes })) { point in
+            LineMark(
+                x: .value("Time", point.timeMinutes),
+                y: .value("Depth", point.normalizedValue),
+                series: .value("Series", "GF99")
+            )
+            .foregroundStyle(Color.purple)
+            .lineStyle(StrokeStyle(lineWidth: 2))
+        }
+    }
+
+    @ChartContentBuilder
+    private var surfGfContent: some ChartContent {
+        ForEach(data.surfGfPoints.prefix(while: { $0.timeMinutes <= visibleTimeMinutes })) { point in
+            LineMark(
+                x: .value("Time", point.timeMinutes),
+                y: .value("Depth", point.normalizedValue),
+                series: .value("Series", "SurfGF")
+            )
+            .foregroundStyle(Color.teal)
+            .lineStyle(StrokeStyle(lineWidth: 2))
+        }
+    }
+
+    @ChartContentBuilder
+    private var decoStopContent: some ChartContent {
+        let bandHalfHeight: Float = depthUnit == .feet ? 1.0 : 0.3
+        ForEach(data.decoStopBands.filter({ $0.startTimeMinutes <= visibleTimeMinutes })) { band in
+            let visibleEnd = min(band.endTimeMinutes, visibleTimeMinutes)
+            RectangleMark(
+                xStart: .value("Start", band.startTimeMinutes),
+                xEnd: .value("End", visibleEnd),
+                yStart: .value("Top", -(band.depth - bandHalfHeight)),
+                yEnd: .value("Bottom", -(band.depth + bandHalfHeight))
+            )
+            .foregroundStyle(Color.red.opacity(0.15))
+        }
+    }
+
+    @ChartContentBuilder
+    private var gasSwitchContent: some ChartContent {
+        ForEach(data.gasSwitchMarkers.filter({ $0.timeMinutes <= visibleTimeMinutes })) { marker in
+            RuleMark(x: .value("Gas Switch", marker.timeMinutes))
+                .foregroundStyle(marker.color.opacity(0.6))
+                .lineStyle(StrokeStyle(lineWidth: 1, dash: [4, 4]))
+                .annotation(position: .top, alignment: .leading) {
+                    Text(marker.gasLabel)
+                        .font(.caption2)
+                        .foregroundColor(marker.color)
+                        .padding(2)
+                        #if os(iOS)
+                        .background(Color(.systemBackground).opacity(0.8))
+                        #else
+                        .background(Color(.windowBackgroundColor).opacity(0.8))
+                        #endif
+                        .cornerRadius(3)
+                }
+        }
+    }
+
+    @ChartContentBuilder
+    private var phaseMarkerContent: some ChartContent {
+        if data.descentEndTimeMinutes > 0, data.descentEndTimeMinutes <= visibleTimeMinutes {
+            RuleMark(x: .value("Descent End", data.descentEndTimeMinutes))
+                .foregroundStyle(Color.gray.opacity(0.3))
+                .lineStyle(StrokeStyle(lineWidth: 1, dash: [6, 3]))
+        }
+        if data.bottomEndTimeMinutes > 0, data.bottomEndTimeMinutes <= visibleTimeMinutes {
+            RuleMark(x: .value("Bottom End", data.bottomEndTimeMinutes))
+                .foregroundStyle(Color.gray.opacity(0.3))
+                .lineStyle(StrokeStyle(lineWidth: 1, dash: [6, 3]))
+        }
+    }
+
+    @ChartContentBuilder
+    private var scrubContent: some ChartContent {
+        if let selectedPoint {
+            RuleMark(x: .value("Selected", selectedPoint.timeMinutes))
+                .foregroundStyle(Color.gray.opacity(isFullscreen ? 0.7 : 0.5))
+                .lineStyle(StrokeStyle(
+                    lineWidth: isFullscreen ? 1.5 : 1,
+                    dash: isFullscreen ? [] : [4, 4]
+                ))
+        }
+    }
+
+    // MARK: - Readout bar
+
+    private var readoutBar: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: isFullscreen ? 12 : 8) {
+                if let tSec = selectedTSec {
+                    if let d = data.depthLookup[tSec] {
+                        Text(String(format: "%.1f%@", d, UnitFormatter.depthLabel(depthUnit)))
+                            .fontWeight(.semibold)
+                    }
+                    let mins = tSec / 60
+                    let secs = tSec % 60
+                    Text("\(mins):\(String(format: "%02d", secs))")
+                        .foregroundColor(.secondary)
+                    if let gas = data.gasLookup[tSec] {
+                        Text(gas).foregroundColor(.mint)
+                    }
+                    if let ceil = data.ceilingLookup[tSec] {
+                        Text("CEIL \(UnitFormatter.formatDepth(ceil, unit: depthUnit))")
+                            .foregroundColor(.red)
+                    }
+                    if let tts = data.ttsLookup[tSec] {
+                        Text("TTS \(tts / 60):\(String(format: "%02d", tts % 60))")
+                            .foregroundColor(.red)
+                    }
+                    if let ndl = data.ndlLookup[tSec] {
+                        Text("NDL \(ndl / 60):\(String(format: "%02d", ndl % 60))")
+                            .foregroundColor(.green)
+                    }
+                    if showGf99, let gf = data.gf99Lookup[tSec] {
+                        Text(String(format: "GF99 %.0f%%", gf))
+                            .foregroundColor(.purple)
+                    }
+                    if showSurfGf, let sgf = data.surfGfLookup[tSec] {
+                        Text(String(format: "SurfGF %.0f%%", sgf))
+                            .foregroundColor(.teal)
+                    }
+                }
+            }
+            .font(isFullscreen ? .caption : .caption2)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(readoutBackground)
+        .cornerRadius(6)
+    }
+
+    private var selectedTSec: Int32? {
+        guard let selectedTime else { return nil }
+        return data.nearestTSec(to: selectedTime, in: samples)
+    }
+
+    private var readoutBackground: some ShapeStyle {
+        #if os(iOS)
+        Color(.systemBackground).opacity(0.85)
+        #else
+        Color(.windowBackgroundColor).opacity(0.85)
+        #endif
+    }
+
+    // MARK: - Accessibility
+
+    private var chartAccessibilityLabel: String {
+        let depthStr = String(format: "%.1f%@", data.maxDepth, UnitFormatter.depthLabel(depthUnit))
+        let totalMin = Int(data.totalMinutes.rounded())
+        let animMin = Int(visibleTimeMinutes.rounded())
+        var label = "Replay profile chart. Showing \(animMin) of \(totalMin) minutes. Maximum depth \(depthStr)."
+        if !data.decoStopBands.isEmpty {
+            label += " \(data.decoStopBands.count) deco stop\(data.decoStopBands.count == 1 ? "" : "s")."
+        }
+        if !data.gasSwitchMarkers.isEmpty {
+            label += " \(data.gasSwitchMarkers.count) gas switch\(data.gasSwitchMarkers.count == 1 ? "" : "es")."
+        }
+        return label
+    }
+}
+
+// MARK: - Replay chart section (inline in sheet)
+
+struct ReplayChartSection: View {
+    let chartData: ReplayChartData
+    let samples: [SampleInput]
+    let depthUnit: DepthUnit
+
+    @State private var controller: ReplayAnimationController?
+    @State private var showFullscreen = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Profile")
+                    .font(.headline)
+                Spacer()
+                Button {
+                    showFullscreen = true
+                } label: {
+                    Image(systemName: "arrow.up.left.and.arrow.down.right")
+                        .font(.caption)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Open fullscreen chart")
+            }
+
+            if let controller {
+                ReplayChart(
+                    data: chartData,
+                    visibleTimeMinutes: controller.visibleTimeMinutes,
+                    samples: samples,
+                    depthUnit: depthUnit
+                )
+                .frame(height: 250)
+
+                animationControls(controller: controller)
+            }
+        }
+        .onAppear {
+            self.controller = ReplayAnimationController(totalTimeSec: chartData.totalMinutes * 60.0)
+        }
+        .onDisappear {
+            controller?.pause()
+        }
+        #if os(iOS)
+        .fullScreenCover(isPresented: $showFullscreen) {
+            if let controller {
+                ReplayChartFullscreenView(
+                    data: chartData,
+                    controller: controller,
+                    samples: samples,
+                    depthUnit: depthUnit
+                )
+            }
+        }
+        #else
+        .sheet(isPresented: $showFullscreen) {
+            if let controller {
+                ReplayChartFullscreenView(
+                    data: chartData,
+                    controller: controller,
+                    samples: samples,
+                    depthUnit: depthUnit
+                )
+                .frame(minWidth: 800)
+                .frame(minHeight: 500)
+            }
+        }
+        #endif
+    }
+
+    private func animationControls(controller: ReplayAnimationController) -> some View {
+        VStack(spacing: 8) {
+            // Slider
+            Slider(
+                value: Binding(
+                    get: { controller.visibleTimeSec },
+                    set: { controller.scrub(to: $0) }
+                ),
+                in: 0 ... max(controller.totalTimeSec, 1)
+            )
+            .accessibilityLabel("Animation progress")
+            .accessibilityValue(controller.currentTimeLabel)
+
+            HStack(spacing: 12) {
+                // Transport controls
+                Button { controller.reset() } label: {
+                    Image(systemName: "backward.end.fill").frame(width: 24)
+                }
+                .accessibilityLabel("Reset")
+
+                Button {
+                    if let slower = controller.speed.slower { controller.speed = slower }
+                } label: {
+                    Image(systemName: "backward.fill").frame(width: 24)
+                }
+                .disabled(controller.speed.slower == nil)
+                .accessibilityLabel("Slower")
+
+                Button {
+                    if controller.isPlaying { controller.pause() } else { controller.play() }
+                } label: {
+                    Image(systemName: controller.isPlaying ? "pause.fill" : "play.fill")
+                        .frame(width: 24)
+                }
+                .accessibilityLabel(controller.isPlaying ? "Pause" : "Play")
+
+                Button {
+                    if let faster = controller.speed.faster { controller.speed = faster }
+                } label: {
+                    Image(systemName: "forward.fill").frame(width: 24)
+                }
+                .disabled(controller.speed.faster == nil)
+                .accessibilityLabel("Faster")
+
+                Text(controller.speed.label)
+                    .font(.caption2)
+                    .monospacedDigit()
+                    .foregroundColor(.secondary)
+
+                Spacer()
+
+                Text(controller.currentTimeLabel)
+                    .font(.caption)
+                    .monospacedDigit()
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+}

--- a/Profundum/Profundum/Views/ReplayChart.swift
+++ b/Profundum/Profundum/Views/ReplayChart.swift
@@ -258,7 +258,17 @@ struct ReplayChartData {
     // MARK: - Actual dive initializer
 
     // swiftlint:disable:next function_body_length
-    init(samples: [DiveSample], decoResult: DecoSimResult, gasMixes: [GasMix], depthUnit: DepthUnit) {
+    init(
+        samples rawSamples: [DiveSample],
+        decoResult: DecoSimResult,
+        plannedStops: [DecoStop],
+        gasMixes: [GasMix],
+        depthUnit: DepthUnit
+    ) {
+        // Defensive sort: binary search / band matching below assume monotonic tSec.
+        // Real imports are ordered, but tolerate out-of-order input without silent
+        // scrub/readout corruption.
+        let samples = rawSamples.sorted { $0.tSec < $1.tSec }
         let decoPoints = decoResult.points
 
         // -- Depth points from DiveSample --
@@ -392,10 +402,68 @@ struct ReplayChartData {
         self.gasSwitchMarkers = markers
         self.gasLookup = gasLook
 
-        // No deco stop bands for actual dives (no planned stops)
-        self.decoStopBands = []
+        // -- Deco stop bands from pass-1 planned stops --
+        // Actual dives have no explicit bottom_end_t; use the max-depth sample index
+        // as a proxy so descent pass-through at stop depths can't open bands.
+        // Tolerance is 1.0 m (vs. 0.5 m for synthetic) because real divers don't
+        // hold stop depths exactly.
+        var bands: [DecoStopBand] = []
+        if !plannedStops.isEmpty, !samples.isEmpty {
+            var maxDepthIdx = 0
+            var maxDepthValue: Float = 0
+            for (i, s) in samples.enumerated() where s.depthM > maxDepthValue {
+                maxDepthValue = s.depthM
+                maxDepthIdx = i
+            }
+            let bottomEnd = samples[maxDepthIdx].tSec
+            var stopQueue = plannedStops[...]
+            var bandStart: Int32?
+            var bandDepthM: Float = 0
 
-        // No phase markers for actual dives
+            for s in samples where s.tSec >= bottomEnd {
+                guard let nextStop = stopQueue.first else { break }
+                if abs(s.depthM - nextStop.depthM) < 1.0 {
+                    if bandStart == nil {
+                        bandStart = s.tSec
+                        bandDepthM = nextStop.depthM
+                    }
+                } else if let start = bandStart {
+                    let durSec = s.tSec - start
+                    let gasLabel = mixLabels[Int(nextStop.gasMixIndex)]
+                    let durLabel = durSec >= 60
+                        ? "\(durSec / 60) min"
+                        : "\(durSec) sec"
+                    bands.append(DecoStopBand(
+                        id: bands.count,
+                        startTimeMinutes: Float(start) / 60.0,
+                        endTimeMinutes: Float(s.tSec) / 60.0,
+                        depth: UnitFormatter.depth(bandDepthM, unit: depthUnit),
+                        gasLabel: gasLabel,
+                        durationLabel: durLabel
+                    ))
+                    bandStart = nil
+                    stopQueue = stopQueue.dropFirst()
+                }
+            }
+            if let start = bandStart, let nextStop = stopQueue.first, let lastSample = samples.last {
+                let durSec = lastSample.tSec - start
+                let gasLabel = mixLabels[Int(nextStop.gasMixIndex)]
+                let durLabel = durSec >= 60
+                    ? "\(durSec / 60) min"
+                    : "\(durSec) sec"
+                bands.append(DecoStopBand(
+                    id: bands.count,
+                    startTimeMinutes: Float(start) / 60.0,
+                    endTimeMinutes: Float(lastSample.tSec) / 60.0,
+                    depth: UnitFormatter.depth(bandDepthM, unit: depthUnit),
+                    gasLabel: gasLabel,
+                    durationLabel: durLabel
+                ))
+            }
+        }
+        self.decoStopBands = bands
+
+        // No explicit phase markers for actual dives.
         self.descentEndTimeMinutes = 0
         self.bottomEndTimeMinutes = 0
     }

--- a/Profundum/Profundum/Views/ReplayChartFullscreenView.swift
+++ b/Profundum/Profundum/Views/ReplayChartFullscreenView.swift
@@ -1,0 +1,175 @@
+import DivelogCore
+import SwiftUI
+
+struct ReplayChartFullscreenView: View {
+    let data: ReplayChartData
+    @Bindable var controller: ReplayAnimationController
+    let samples: [SampleInput]
+    let depthUnit: DepthUnit
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var showCeiling = true
+    @State private var showGf99 = false
+    @State private var showSurfGf = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Top bar with overlay toggles
+            HStack(spacing: 10) {
+                Text("Replay Profile")
+                    .font(.headline)
+
+                if data.hasCeilingData {
+                    ChartOverlayChip(label: "Ceiling", color: .red, isActive: showCeiling) {
+                        showCeiling.toggle()
+                    }
+                }
+
+                if data.hasGf99Data {
+                    ChartOverlayChip(label: "GF99", color: .purple, isActive: showGf99) {
+                        showGf99.toggle()
+                    }
+                }
+
+                if data.hasSurfGfData {
+                    ChartOverlayChip(label: "SurfGF", color: .teal, isActive: showSurfGf) {
+                        showSurfGf.toggle()
+                    }
+                }
+
+                Spacer()
+
+                Button {
+                    controller.pause()
+                    dismiss()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.body.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Close fullscreen chart")
+            }
+            .padding()
+
+            Divider()
+
+            // Chart
+            ReplayChart(
+                data: data,
+                visibleTimeMinutes: controller.visibleTimeMinutes,
+                samples: samples,
+                showCeiling: showCeiling,
+                showGf99: showGf99,
+                showSurfGf: showSurfGf,
+                isFullscreen: true,
+                depthUnit: depthUnit
+            )
+            .frame(maxHeight: .infinity)
+            .padding(.horizontal)
+
+            Divider()
+
+            // Animation controls
+            fullscreenControls
+                .padding()
+        }
+        .onDisappear {
+            controller.pause()
+        }
+        #if os(iOS)
+        .background(Color(.systemBackground))
+        .onAppear {
+            AppDelegate.orientationLock = .landscape
+            requestOrientation(.landscape)
+        }
+        .onDisappear {
+            AppDelegate.orientationLock = .all
+        }
+        #else
+        .background(Color(.windowBackgroundColor))
+        #endif
+    }
+
+    private var fullscreenControls: some View {
+        VStack(spacing: 8) {
+            Slider(
+                value: Binding(
+                    get: { controller.visibleTimeSec },
+                    set: { controller.scrub(to: $0) }
+                ),
+                in: 0 ... max(controller.totalTimeSec, 1)
+            )
+            .accessibilityLabel("Animation progress")
+            .accessibilityValue(controller.currentTimeLabel)
+
+            HStack(spacing: 16) {
+                // Transport controls: rewind, slow, play/pause, fast, fast-forward
+                Button {
+                    controller.reset()
+                } label: {
+                    Image(systemName: "backward.end.fill")
+                        .font(.title3)
+                        .frame(width: 32)
+                }
+                .accessibilityLabel("Reset to start")
+
+                Button {
+                    if let slower = controller.speed.slower {
+                        controller.speed = slower
+                    }
+                } label: {
+                    Image(systemName: "backward.fill")
+                        .font(.title3)
+                        .frame(width: 32)
+                }
+                .disabled(controller.speed.slower == nil)
+                .accessibilityLabel("Slower")
+
+                Button {
+                    if controller.isPlaying {
+                        controller.pause()
+                    } else {
+                        controller.play()
+                    }
+                } label: {
+                    Image(systemName: controller.isPlaying ? "pause.fill" : "play.fill")
+                        .font(.title3)
+                        .frame(width: 32)
+                }
+                .accessibilityLabel(controller.isPlaying ? "Pause" : "Play")
+
+                Button {
+                    if let faster = controller.speed.faster {
+                        controller.speed = faster
+                    }
+                } label: {
+                    Image(systemName: "forward.fill")
+                        .font(.title3)
+                        .frame(width: 32)
+                }
+                .disabled(controller.speed.faster == nil)
+                .accessibilityLabel("Faster")
+
+                Text(controller.speed.label)
+                    .font(.caption)
+                    .monospacedDigit()
+                    .foregroundColor(.secondary)
+                    .frame(width: 40)
+
+                Text(controller.currentTimeLabel)
+                    .font(.body)
+                    .monospacedDigit()
+                    .foregroundColor(.secondary)
+
+            }
+        }
+    }
+
+    #if os(iOS)
+    private func requestOrientation(_ orientations: UIInterfaceOrientationMask) {
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return }
+        windowScene.requestGeometryUpdate(.iOS(interfaceOrientations: orientations))
+    }
+    #endif
+}

--- a/Profundum/Profundum/Views/ReplayChartFullscreenView.swift
+++ b/Profundum/Profundum/Views/ReplayChartFullscreenView.swift
@@ -79,12 +79,24 @@ struct ReplayChartFullscreenView: View {
         }
         #if os(iOS)
         .background(Color(.systemBackground))
+        // fullScreenCover has no built-in swipe-to-dismiss; child gestures
+        // (chart scrub, slider) take precedence over this parent gesture.
+        .gesture(
+            DragGesture(minimumDistance: 30)
+                .onEnded { value in
+                    if value.translation.height > 80 {
+                        controller.pause()
+                        dismiss()
+                    }
+                }
+        )
         .onAppear {
             AppDelegate.orientationLock = .landscape
             requestOrientation(.landscape)
         }
         .onDisappear {
             AppDelegate.orientationLock = .all
+            requestOrientation(.portrait)
         }
         #else
         .background(Color(.windowBackgroundColor))
@@ -170,6 +182,10 @@ struct ReplayChartFullscreenView: View {
     private func requestOrientation(_ orientations: UIInterfaceOrientationMask) {
         guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return }
         windowScene.requestGeometryUpdate(.iOS(interfaceOrientations: orientations))
+        // UIKit caches supportedInterfaceOrientations; without this the
+        // orientationLock reset is never picked up and rotation stays stuck.
+        windowScene.keyWindow?.rootViewController?
+            .setNeedsUpdateOfSupportedInterfaceOrientations()
     }
     #endif
 }

--- a/Profundum/Profundum/Views/ReplayProfileSheet.swift
+++ b/Profundum/Profundum/Views/ReplayProfileSheet.swift
@@ -48,7 +48,8 @@ struct ReplayProfileSheet: View {
 
     enum ReplayResult {
         case synthetic(ProfileGenResult)
-        case actual(DecoSimResult)
+        /// Actual-dive result: overlay (full profile) + planned stops (from bottom-end)
+        case actual(overlay: DecoSimResult, planned: DecoSimResult)
     }
 
     @State private var result: ReplayResult?
@@ -451,10 +452,40 @@ struct ReplayProfileSheet: View {
         .accessibilityLabel("Error: \(message)")
     }
 
+    @ViewBuilder
     private func resultSummary(_ result: ReplayResult) -> some View {
         let extracted = extractResultData(result)
         let isActual = if case .actual = result { true } else { false }
-        return resultGrid(
+
+        // Chart section
+        let chartData: ReplayChartData = {
+            switch result {
+            case .synthetic(let profileResult):
+                return ReplayChartData(result: profileResult, depthUnit: appState.depthUnit)
+            case .actual(let overlay, _):
+                return ReplayChartData(
+                    samples: samples, decoResult: overlay,
+                    gasMixes: gasMixes, depthUnit: appState.depthUnit
+                )
+            }
+        }()
+
+        let sampleInputs: [SampleInput] = {
+            switch result {
+            case .synthetic(let profileResult):
+                return profileResult.samples
+            case .actual:
+                return samples.toSampleInputs()
+            }
+        }()
+
+        ReplayChartSection(
+            chartData: chartData,
+            samples: sampleInputs,
+            depthUnit: appState.depthUnit
+        )
+
+        resultGrid(
             decoResult: extracted.decoResult,
             totalTimeSec: extracted.totalTimeSec,
             decoTimeSec: extracted.decoTimeSec,
@@ -471,9 +502,9 @@ struct ReplayProfileSheet: View {
                 profileResult.totalTimeSec,
                 profileResult.totalTimeSec - profileResult.bottomEndTSec
             )
-        case .actual(let simResult):
+        case .actual(let overlay, let planned):
             let totalTime = samples.last.map { $0.tSec } ?? 0
-            return (simResult, totalTime, simResult.totalDecoTimeSec)
+            return (overlay, totalTime, planned.totalDecoTimeSec)
         }
     }
 
@@ -757,14 +788,22 @@ struct ReplayProfileSheet: View {
             return
         }
 
-        let params = buildDecoSimParams()
+        // Two engine calls:
+        // 1. Full samples with planAscent: false → per-point ceiling/GF99 overlay for charting
+        // 2. Truncated samples with planAscent: true → planned deco stop schedule
+        let overlayParams = buildDecoSimParams(truncate: false, planAscent: false)
+        let planParams = buildDecoSimParams(truncate: true, planAscent: true)
+
+        guard !overlayParams.samples.isEmpty, !planParams.samples.isEmpty else { return }
 
         Task {
             do {
-                let decoResult = try await Task.detached {
-                    try DivelogCompute.computeDecoSimulation(params: params)
+                let (overlay, planned) = try await Task.detached {
+                    let o = try DivelogCompute.computeDecoSimulation(params: overlayParams)
+                    let p = try DivelogCompute.computeDecoSimulation(params: planParams)
+                    return (o, p)
                 }.value
-                result = .actual(decoResult)
+                result = .actual(overlay: overlay, planned: planned)
                 isGenerating = false
             } catch {
                 errorMessage = error.localizedDescription
@@ -801,25 +840,27 @@ struct ReplayProfileSheet: View {
         }
     }
 
-    private func buildDecoSimParams() -> DecoSimParams {
+    private func buildDecoSimParams(truncate: Bool = true, planAscent: Bool = true) -> DecoSimParams {
         let du = appState.depthUnit
         let sorted = samples.sorted(by: { $0.tSec < $1.tSec })
 
-        // Truncate samples at the bottom-end point so the engine plans the ascent
-        // from peak tissue loading (not from the surface after the dive is over).
-        // Use DiveStats.bottomEndT when available (handles multi-level dives correctly),
-        // otherwise fall back to 95% of max depth.
-        let bottomEndT: Int32
-        if let s = stats, s.bottomEndT > 0 {
-            bottomEndT = s.bottomEndT
+        let useSamples: [DiveSample]
+        if truncate {
+            // Truncate at bottom-end for ascent planning (peak tissue loading).
+            let bottomEndT: Int32
+            if let s = stats, s.bottomEndT > 0 {
+                bottomEndT = s.bottomEndT
+            } else {
+                let maxDepth = sorted.map(\.depthM).max() ?? 0
+                bottomEndT = sorted.last(where: { $0.depthM >= maxDepth * 0.95 })?.tSec ?? sorted.last?.tSec ?? 0
+            }
+            let bottomEndIdx = sorted.lastIndex(where: { $0.tSec <= bottomEndT }) ?? (sorted.count - 1)
+            useSamples = Array(sorted[...bottomEndIdx])
         } else {
-            let maxDepth = sorted.map(\.depthM).max() ?? 0
-            bottomEndT = sorted.last(where: { $0.depthM >= maxDepth * 0.95 })?.tSec ?? sorted.last?.tSec ?? 0
+            useSamples = sorted
         }
-        let bottomEndIdx = sorted.lastIndex(where: { $0.tSec <= bottomEndT }) ?? (sorted.count - 1)
-        let bottomSamples = Array(sorted[...bottomEndIdx])
 
-        var sampleInputs = bottomSamples.toSampleInputs()
+        var sampleInputs = useSamples.toSampleInputs()
 
         // CCR setpoint override: only if user changed it from the prefilled value.
         // Validate that the override is a valid number.
@@ -890,7 +931,7 @@ struct ReplayProfileSheet: View {
             gfLow: selectedModel == .buhlmannZhl16c ? UInt8(min(max(gfLow, 1), 100)) : nil,
             gfHigh: selectedModel == .buhlmannZhl16c ? UInt8(min(max(gfHigh, 1), 100)) : nil,
             thalmannPdcs: selectedModel == .thalmannElDca ? thalmannPdcs : nil,
-            planAscent: true
+            planAscent: planAscent
         )
     }
 }

--- a/Profundum/Profundum/Views/ReplayProfileSheet.swift
+++ b/Profundum/Profundum/Views/ReplayProfileSheet.swift
@@ -462,10 +462,13 @@ struct ReplayProfileSheet: View {
             switch result {
             case .synthetic(let profileResult):
                 return ReplayChartData(result: profileResult, depthUnit: appState.depthUnit)
-            case .actual(let overlay, _):
+            case .actual(let overlay, let planned):
                 return ReplayChartData(
-                    samples: samples, decoResult: overlay,
-                    gasMixes: gasMixes, depthUnit: appState.depthUnit
+                    samples: samples,
+                    decoResult: overlay,
+                    plannedStops: planned.decoStops,
+                    gasMixes: gasMixes,
+                    depthUnit: appState.depthUnit
                 )
             }
         }()
@@ -796,13 +799,17 @@ struct ReplayProfileSheet: View {
 
         guard !overlayParams.samples.isEmpty, !planParams.samples.isEmpty else { return }
 
+        // Run both engine calls in parallel — they're independent and this
+        // roughly halves perceived latency on larger dives.
         Task {
+            async let overlayTask = Task.detached {
+                try DivelogCompute.computeDecoSimulation(params: overlayParams)
+            }.value
+            async let plannedTask = Task.detached {
+                try DivelogCompute.computeDecoSimulation(params: planParams)
+            }.value
             do {
-                let (overlay, planned) = try await Task.detached {
-                    let o = try DivelogCompute.computeDecoSimulation(params: overlayParams)
-                    let p = try DivelogCompute.computeDecoSimulation(params: planParams)
-                    return (o, p)
-                }.value
+                let (overlay, planned) = try await (overlayTask, plannedTask)
                 result = .actual(overlay: overlay, planned: planned)
                 isGenerating = false
             } catch {

--- a/Profundum/Profundum/Views/ReplayProfileSheet.swift
+++ b/Profundum/Profundum/Views/ReplayProfileSheet.swift
@@ -478,7 +478,9 @@ struct ReplayProfileSheet: View {
             case .synthetic(let profileResult):
                 return profileResult.samples
             case .actual:
-                return samples.toSampleInputs()
+                // Sort to match ReplayChartData's defensive sort — nearestTSec
+                // binary-searches this array assuming monotonic tSec.
+                return samples.sorted { $0.tSec < $1.tSec }.toSampleInputs()
             }
         }()
 
@@ -506,7 +508,9 @@ struct ReplayProfileSheet: View {
                 profileResult.totalTimeSec - profileResult.bottomEndTSec
             )
         case .actual(let overlay, let planned):
-            let totalTime = samples.last.map { $0.tSec } ?? 0
+            // Max rather than .last — samples may be unsorted (see defensive
+            // sort in buildDecoSimParams / ReplayChartData).
+            let totalTime = samples.map(\.tSec).max() ?? 0
             return (overlay, totalTime, planned.totalDecoTimeSec)
         }
     }
@@ -797,7 +801,11 @@ struct ReplayProfileSheet: View {
         let overlayParams = buildDecoSimParams(truncate: false, planAscent: false)
         let planParams = buildDecoSimParams(truncate: true, planAscent: true)
 
-        guard !overlayParams.samples.isEmpty, !planParams.samples.isEmpty else { return }
+        guard !overlayParams.samples.isEmpty, !planParams.samples.isEmpty else {
+            errorMessage = "No usable samples for deco simulation."
+            isGenerating = false
+            return
+        }
 
         // Run both engine calls in parallel — they're independent and this
         // roughly halves perceived latency on larger dives.

--- a/apple/DivelogCore/Tests/RustBridgeMappingTests.swift
+++ b/apple/DivelogCore/Tests/RustBridgeMappingTests.swift
@@ -140,4 +140,73 @@ final class RustBridgeMappingTests: XCTestCase {
         XCTAssertEqual(result[0].o2Fraction, Double(Float(0.18)), accuracy: 1e-6)
         XCTAssertEqual(result[0].heFraction, Double(Float(0.45)), accuracy: 1e-6)
     }
+
+    // MARK: - ProfileGenResult.plannedStops (PRO-51)
+
+    /// A shallow NDL dive must round-trip through the FFI with an empty
+    /// `plannedStops` array — exercising the new field on the no-deco path.
+    func testGenerateDiveProfileShallowHasNoPlannedStops() throws {
+        let params = ProfileGenParams(
+            targetDepthM: 12.0,
+            bottomTimeSec: 1800,
+            descentRateMMin: nil,
+            ascentRateMMin: nil,
+            gasPlan: [],
+            model: .buhlmannZhl16c,
+            surfacePressureBar: nil,
+            gfLow: nil,
+            gfHigh: nil,
+            lastStopDepthM: nil,
+            stopIntervalM: nil,
+            setpointPpo2: nil,
+            thalmannPdcs: nil,
+            sampleIntervalSec: nil,
+            tempC: nil
+        )
+        let result = try DivelogCompute.generateDiveProfile(params: params)
+        XCTAssertTrue(result.plannedStops.isEmpty,
+                      "Shallow NDL dive should produce no planned stops")
+    }
+
+    /// A deep air dive with conservative GFs must populate `plannedStops`
+    /// across the FFI boundary with valid depth/duration and deepest-first
+    /// ordering — guards against regressions in the UniFFI field mapping
+    /// introduced in PRO-51.
+    func testGenerateDiveProfilePlannedStopsRoundTrip() throws {
+        let params = ProfileGenParams(
+            targetDepthM: 40.0,
+            bottomTimeSec: 1200,
+            descentRateMMin: nil,
+            ascentRateMMin: nil,
+            gasPlan: [],
+            model: .buhlmannZhl16c,
+            surfacePressureBar: nil,
+            gfLow: 50,
+            gfHigh: 80,
+            lastStopDepthM: nil,
+            stopIntervalM: nil,
+            setpointPpo2: nil,
+            thalmannPdcs: nil,
+            sampleIntervalSec: nil,
+            tempC: nil
+        )
+        let result = try DivelogCompute.generateDiveProfile(params: params)
+
+        XCTAssertFalse(result.plannedStops.isEmpty,
+                       "Deep dive with conservative GFs should produce planned stops")
+
+        for pair in zip(result.plannedStops, result.plannedStops.dropFirst()) {
+            XCTAssertGreaterThanOrEqual(pair.0.depthM, pair.1.depthM,
+                                        "plannedStops must be sorted deepest-first")
+        }
+
+        for stop in result.plannedStops {
+            XCTAssertGreaterThan(stop.durationSec, 0,
+                                 "Each planned stop must have a positive duration")
+            XCTAssertGreaterThan(stop.depthM, 0,
+                                 "Stop depth must be > 0")
+            XCTAssertLessThan(stop.depthM, 40.0,
+                              "Stop depth must be shallower than bottom")
+        }
+    }
 }

--- a/core/src/deco/profile_generator.rs
+++ b/core/src/deco/profile_generator.rs
@@ -73,9 +73,10 @@ pub struct ProfileGenResult {
     /// Gas mixes used in the profile.
     pub gas_mixes: Vec<GasMixInput>,
     /// Full deco simulation result (pass 2) with per-point overlay data.
-    /// Note: `deco_result.deco_stops` is empty because pass 2 uses `plan_ascent: false`.
-    /// The deco stop schedule is baked into the sample profile shape (ascent holds).
     pub deco_result: DecoSimResult,
+    /// Planned deco stops from pass 1 (with depths and durations).
+    /// These are the stops used to build the ascent profile.
+    pub planned_stops: Vec<DecoStop>,
     /// Time at end of descent phase (seconds).
     pub descent_end_t_sec: i32,
     /// Time at end of bottom phase (seconds).
@@ -215,6 +216,7 @@ pub fn generate_dive_profile(params: ProfileGenParams) -> Result<ProfileGenResul
         samples,
         gas_mixes,
         deco_result,
+        planned_stops: pass1_result.deco_stops,
         descent_end_t_sec: descent_end_t,
         bottom_end_t_sec: bottom_end_t,
         total_time_sec,
@@ -1112,6 +1114,73 @@ mod tests {
             "Shallow dive should have no deco stops"
         );
         assert_eq!(result.deco_result.total_deco_time_sec, 0);
+        assert!(
+            result.planned_stops.is_empty(),
+            "No-deco dive should also have no planned stops"
+        );
+    }
+
+    #[test]
+    fn test_planned_stops_surface_deco_dive() {
+        // Deep dive with deco — planned_stops (from pass-1 planner) must be
+        // populated with shallower-than-bottom stops sorted deepest-first,
+        // and each stop must have a positive duration.
+        let mut params = air_params(40.0, 1200);
+        params.gf_low = Some(50);
+        params.gf_high = Some(80);
+        let result = generate_dive_profile(params).unwrap();
+
+        assert!(
+            !result.planned_stops.is_empty(),
+            "Deep dive with conservative GFs should produce planned stops"
+        );
+
+        // Deepest-first ordering.
+        for pair in result.planned_stops.windows(2) {
+            assert!(
+                pair[0].depth_m >= pair[1].depth_m,
+                "planned_stops must be sorted deepest-first: {} before {}",
+                pair[0].depth_m,
+                pair[1].depth_m,
+            );
+        }
+
+        for stop in &result.planned_stops {
+            assert!(
+                stop.duration_sec > 0,
+                "Each planned stop must have a positive duration, got {}",
+                stop.duration_sec
+            );
+            assert!(
+                stop.depth_m > 0.0 && (stop.depth_m as f64) < 40.0,
+                "Stop depth must be shallower than bottom: {}",
+                stop.depth_m
+            );
+        }
+
+        // The pass-1 stop schedule should shape the sample ascent: for each
+        // planned stop depth there must be at least two consecutive samples
+        // at that depth (the "hold").
+        for stop in &result.planned_stops {
+            let mut consecutive_at_depth = 0;
+            let mut saw_hold = false;
+            for s in result.samples.iter() {
+                if (s.depth_m - stop.depth_m).abs() < 0.01 {
+                    consecutive_at_depth += 1;
+                    if consecutive_at_depth >= 2 {
+                        saw_hold = true;
+                        break;
+                    }
+                } else {
+                    consecutive_at_depth = 0;
+                }
+            }
+            assert!(
+                saw_hold,
+                "Samples should include a hold at planned stop depth {}",
+                stop.depth_m
+            );
+        }
     }
 
     #[test]

--- a/core/src/divelog_compute.udl
+++ b/core/src/divelog_compute.udl
@@ -236,6 +236,7 @@ dictionary ProfileGenResult {
     sequence<SampleInput> samples;
     sequence<GasMixInput> gas_mixes;
     DecoSimResult deco_result;
+    sequence<DecoStop> planned_stops;
     i32 descent_end_t_sec;
     i32 bottom_end_t_sec;
     i32 total_time_sec;


### PR DESCRIPTION
## Summary

Phase 4 of the dive replay engine (PRO-23). Ports the animation work from closed PR #160 forward onto latest main now that PRO-60 (deco accuracy) and PRO-61 (actual-dive samples) have reshaped `ReplayProfileSheet`.

- `ReplayChartData` precomputes depth, ceiling, GF99, SurfGF, gas-switch, and deco-stop data with O(1) scrub lookups.
- `ReplayChartFullscreenView` presents the chart landscape with overlay toggle chips (Ceiling, GF99, SurfGF).
- `ReplayProfileSheet` wires the chart into the existing parameter sheet.
- `planned_stops` added to `ProfileGenResult` (Rust + UDL + Swift bindings) to surface the pass-1 stop schedule for chart band visualization.

Closes PRO-51. Supersedes #160 (closed due to `ReplayProfileSheet` conflicts from PRO-60/61). Completes the "Replay Complete" milestone and unblocks PRO-53 (Phase 5 comparison view).

## Tests

- **Rust (2 new):** `test_planned_stops_surface_deco_dive`, `test_shallow_no_deco` (extended) — ordering, duration, and sample-hold correspondence.
- **Swift (2 new):** FFI round-trip for `plannedStops` on both shallow NDL (empty) and deep conservative-GF (non-empty) profiles.
- Full suites green locally: Rust 303 pass, Swift 400 pass, SwiftLint 0 violations.

## Test plan

- [x] Open a dive, Replay, configure params, Generate, verify stat cards + chart appear
- [x] Play, verify progressive drawing at selected speed (1x–60x)
- [x] Pause, drag slider, verify scrub
- [x] Change speed mid-animation
- [x] Reset clears to time 0
- [x] Fullscreen + landscape, overlay chips (Ceiling, GF99, SurfGF) toggle
- [x] Close fullscreen via X button and via swipe gesture, verify timer pauses
- [x] No-deco dive: no ceiling/stops, clean depth line
- [x] Deep deco dive with gas switches: stop bands + switch markers render correctly
- [x] Shallow dive: empty stop bands

## Follow-ups

- PRO-53 (Phase 5): side-by-side comparison of real vs simulated stats

Made with [Cursor](https://cursor.com)