### PR TITLE
Fix stuck landscape orientation in depth profile fullscreen (PRO-65)

### DIFF
--- a/Profundum/Profundum/Helpers/LandscapeFullscreenModifier.swift
+++ b/Profundum/Profundum/Helpers/LandscapeFullscreenModifier.swift
@@ -22,7 +22,10 @@ struct LandscapeFullscreenModifier: ViewModifier {
             .gesture(
                 DragGesture(minimumDistance: 30)
                     .onEnded { value in
-                        if value.translation.height > 80 {
+                        // Dominant-axis check: a diagonal chart scrub can exceed
+                        // 80pt vertically; only dismiss on a clearly downward swipe.
+                        let translation = value.translation
+                        if translation.height > 80, translation.height > abs(translation.width) {
                             onSwipeDismiss?()
                             dismiss()
                         }
@@ -39,7 +42,11 @@ struct LandscapeFullscreenModifier: ViewModifier {
     }
 
     static func requestOrientation(_ orientations: UIInterfaceOrientationMask) {
-        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return }
+        // Prefer the foreground-active scene: `connectedScenes.first` can be a
+        // background or wrong scene under iPad multitasking / Stage Manager.
+        let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+        guard let windowScene = scenes.first(where: { $0.activationState == .foregroundActive })
+            ?? scenes.first else { return }
         windowScene.requestGeometryUpdate(.iOS(interfaceOrientations: orientations))
         windowScene.keyWindow?.rootViewController?
             .setNeedsUpdateOfSupportedInterfaceOrientations()

--- a/Profundum/Profundum/Helpers/LandscapeFullscreenModifier.swift
+++ b/Profundum/Profundum/Helpers/LandscapeFullscreenModifier.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+#if os(iOS)
+/// Locks the view to landscape while presented and restores portrait +
+/// free rotation on dismissal. Also adds a downward swipe-to-dismiss
+/// gesture, since `fullScreenCover` has no built-in interactive dismissal.
+///
+/// UIKit caches the result of `supportedInterfaceOrientationsFor`, so
+/// resetting `AppDelegate.orientationLock` alone is never picked up —
+/// `setNeedsUpdateOfSupportedInterfaceOrientations()` must be called for
+/// the change to take effect (otherwise rotation stays stuck in landscape).
+struct LandscapeFullscreenModifier: ViewModifier {
+    /// Called before dismissing via the swipe gesture (e.g. to pause a timer).
+    var onSwipeDismiss: (() -> Void)?
+
+    @Environment(\.dismiss) private var dismiss
+
+    func body(content: Content) -> some View {
+        content
+            // Child gestures (chart scrub, sliders) take precedence over
+            // this parent gesture.
+            .gesture(
+                DragGesture(minimumDistance: 30)
+                    .onEnded { value in
+                        if value.translation.height > 80 {
+                            onSwipeDismiss?()
+                            dismiss()
+                        }
+                    }
+            )
+            .onAppear {
+                AppDelegate.orientationLock = .landscape
+                Self.requestOrientation(.landscape)
+            }
+            .onDisappear {
+                AppDelegate.orientationLock = .all
+                Self.requestOrientation(.portrait)
+            }
+    }
+
+    static func requestOrientation(_ orientations: UIInterfaceOrientationMask) {
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return }
+        windowScene.requestGeometryUpdate(.iOS(interfaceOrientations: orientations))
+        windowScene.keyWindow?.rootViewController?
+            .setNeedsUpdateOfSupportedInterfaceOrientations()
+    }
+}
+#endif
+
+extension View {
+    /// Landscape lock + swipe-to-dismiss for fullscreen chart views (iOS only;
+    /// no-op on macOS).
+    func landscapeFullscreen(onSwipeDismiss: (() -> Void)? = nil) -> some View {
+        #if os(iOS)
+        modifier(LandscapeFullscreenModifier(onSwipeDismiss: onSwipeDismiss))
+        #else
+        self
+        #endif
+    }
+}

--- a/Profundum/Profundum/Views/DepthProfileFullscreenView.swift
+++ b/Profundum/Profundum/Views/DepthProfileFullscreenView.swift
@@ -170,22 +170,9 @@ struct DepthProfileFullscreenView: View {
         }
         #if os(iOS)
         .background(Color(.systemBackground))
-        .onAppear {
-            AppDelegate.orientationLock = .landscape
-            requestOrientation(.landscape)
-        }
-        .onDisappear {
-            AppDelegate.orientationLock = .all
-        }
         #else
         .background(Color(.windowBackgroundColor))
         #endif
+        .landscapeFullscreen()
     }
-
-    #if os(iOS)
-    private func requestOrientation(_ orientations: UIInterfaceOrientationMask) {
-        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return }
-        windowScene.requestGeometryUpdate(.iOS(interfaceOrientations: orientations))
-    }
-    #endif
 }

--- a/Profundum/Profundum/Views/ReplayChartFullscreenView.swift
+++ b/Profundum/Profundum/Views/ReplayChartFullscreenView.swift
@@ -79,28 +79,10 @@ struct ReplayChartFullscreenView: View {
         }
         #if os(iOS)
         .background(Color(.systemBackground))
-        // fullScreenCover has no built-in swipe-to-dismiss; child gestures
-        // (chart scrub, slider) take precedence over this parent gesture.
-        .gesture(
-            DragGesture(minimumDistance: 30)
-                .onEnded { value in
-                    if value.translation.height > 80 {
-                        controller.pause()
-                        dismiss()
-                    }
-                }
-        )
-        .onAppear {
-            AppDelegate.orientationLock = .landscape
-            requestOrientation(.landscape)
-        }
-        .onDisappear {
-            AppDelegate.orientationLock = .all
-            requestOrientation(.portrait)
-        }
         #else
         .background(Color(.windowBackgroundColor))
         #endif
+        .landscapeFullscreen(onSwipeDismiss: { controller.pause() })
     }
 
     private var fullscreenControls: some View {
@@ -178,14 +160,4 @@ struct ReplayChartFullscreenView: View {
         }
     }
 
-    #if os(iOS)
-    private func requestOrientation(_ orientations: UIInterfaceOrientationMask) {
-        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return }
-        windowScene.requestGeometryUpdate(.iOS(interfaceOrientations: orientations))
-        // UIKit caches supportedInterfaceOrientations; without this the
-        // orientationLock reset is never picked up and rotation stays stuck.
-        windowScene.keyWindow?.rootViewController?
-            .setNeedsUpdateOfSupportedInterfaceOrientations()
-    }
-    #endif
 }


### PR DESCRIPTION
## Summary

- `DepthProfileFullscreenView` had the identical stuck-orientation bug fixed for the replay chart in #163: it reset `AppDelegate.orientationLock` on dismiss but never called `setNeedsUpdateOfSupportedInterfaceOrientations()`, which UIKit requires to re-query supported orientations — so the phone stayed locked in landscape after closing the fullscreen chart.
- Extracts a shared `landscapeFullscreen(onSwipeDismiss:)` view modifier (`Helpers/LandscapeFullscreenModifier.swift`) and adopts it in both `DepthProfileFullscreenView` and `ReplayChartFullscreenView`, removing the duplicated orientation-lock pattern.
- The depth profile fullscreen also gains portrait snap-back on close and downward swipe-to-dismiss, for parity with the replay chart.

Closes PRO-65. Fixes #164.

## Test plan

- [ ] Open a dive → fullscreen depth profile → close via X → returns to portrait, rotation works
- [ ] Fullscreen depth profile → swipe down → dismisses
- [ ] Replay fullscreen chart still locks landscape, swipe-dismisses (pausing animation), and restores portrait
- [ ] macOS sheet presentation unaffected (modifier is a no-op off iOS)

## Validation

- SwiftLint strict: clean
- macOS build: green
- iOS device build: green
- View-layer change only — covered by manual QA per testing standards

Made with [Cursor](https://cursor.com)